### PR TITLE
🎨 Palette: Add ARIA label to remove member button

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-05 - Added ARIA Label to Delete Button
+**Learning:** Icon-only buttons (like Trash icons) require ARIA labels to be accessible to screen reader users.
+**Action:** Always add an `aria-label` to any button that only contains an icon.

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -248,7 +248,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} aria-label="Remove member" className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}


### PR DESCRIPTION
* 💡 What: Added `aria-label="Remove member"` to the trash icon button in the `Households.tsx` file.
* 🎯 Why: Icon-only buttons are inaccessible to screen reader users because there's no text explaining what the button does.
* ♿ Accessibility: Improves screen reader support for managing household members.

---
*PR created automatically by Jules for task [8003828496305062977](https://jules.google.com/task/8003828496305062977) started by @ivanleekk*