### PR TITLE
🎨 Palette: Improve accessibility of form inputs with ARIA bindings

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Form Input Accessibility
+**Learning:** The default Input component in this app was missing proper ARIA bindings between the input element and its helper text, and didn't properly broadcast error states to screen readers. This is a common accessibility pattern that needs to be addressed when building or modifying form inputs.
+**Action:** Always ensure that helper texts and error messages are properly associated with the input element dynamically using `aria-describedby` and broadcast error states to screen readers using `aria-invalid`.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
     const generatedId = React.useId()
     const inputId = id || generatedId
+    const helperId = `${inputId}-helper`
 
     return (
       <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           id={inputId}
           disabled={disabled}
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={helperText ? helperId : undefined}
           className={cn(
             "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500",
             {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         />
         {helperText && (
           <p
+            id={helperId}
             className={cn("text-sm text-base-500", {
               "text-red-500": error && !disabled,
               "text-base-400": disabled,


### PR DESCRIPTION
💡 What: Added `aria-invalid` to the `<input>` element when in an error state and dynamically linked the `<input>` with the helper text using `aria-describedby` and a generated `id`.
🎯 Why: To properly broadcast validation errors and helper texts to screen readers. This ensures that assistive technologies can read out helper texts and error states when an input receives focus, which is a common and critical accessibility pattern.
♿ Accessibility: Improved form input accessibility by providing clear ARIA bindings between input elements and their associated helper/error text, and properly indicating the error state.

Created the `.Jules/palette.md` log file to document this critical learning about ensuring proper ARIA bindings for form components, especially regarding helper texts and error states.

---
*PR created automatically by Jules for task [18182876953257930871](https://jules.google.com/task/18182876953257930871) started by @ivanleekk*