### PR TITLE
⚡ Bolt: Optimize O(N²) charting calculations to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - O(N^2) Performance Bottleneck in Chart Date Traversal
+**Learning:** Developers frequently place `.filter().sort()` methods inside of `.map()` or `.forEach()` loop iterations when constructing chronological charting data that requires looking up "most recent historical entry". In data-heavy systems, this turns an $O(N)$ calculation into an $O(N^2 \log N)$ operation that will actively block the browser's main thread and severely degrade frontend performance.
+**Action:** Always verify loops over dates to see if they call `.filter()` or `.sort()` on arrays inside the loop. Instead, hoist `.sort()` outside the loop and implement a running index/pointer that ticks forward alongside the date array to keep track of the most recent value in $O(N)$ time.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -94,16 +94,26 @@ export default function Accounts() {
 
         const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
 
+        // Pre-sort each account's history once
+        const sortedHistories = accounts.map(acc =>
+            [...acc.history].sort((a, b) => a.date.localeCompare(b.date))
+        );
+
+        // Keep running pointers for each account
+        const indices = new Array(accounts.length).fill(0);
+
         return sortedDates.map(date => {
             const dataPoint: any = { date };
 
-            accounts.forEach(acc => {
-                const pastOrCurrentEntries = acc.history
-                    .filter(h => h.date <= date)
-                    .sort((a, b) => a.date.localeCompare(b.date));
+            accounts.forEach((acc, i) => {
+                const history = sortedHistories[i];
 
-                if (pastOrCurrentEntries.length > 0) {
-                    dataPoint[acc.name] = Number(pastOrCurrentEntries[pastOrCurrentEntries.length - 1].balance);
+                while (indices[i] < history.length - 1 && history[indices[i] + 1].date <= date) {
+                    indices[i]++;
+                }
+
+                if (history.length > 0 && history[indices[i]].date <= date) {
+                    dataPoint[acc.name] = Number(history[indices[i]].balance);
                 } else {
                     dataPoint[acc.name] = 0;
                 }

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -68,12 +68,28 @@ export default function Dashboard() {
 
         const sortedDates = Array.from(allDates).sort((a, b) => a.localeCompare(b));
 
+        // Pre-sort historical data O(N log N)
+        const sortedBalances = Object.values(balances).map(history =>
+            [...history].sort((a, b) => a.date.localeCompare(b.date))
+        );
+
+        const subPortfolioIds = Array.from(new Set(snapshots.map(s => s.sub_portfolio_id)));
+        const sortedSnapshotsBySp = subPortfolioIds.map(spId =>
+            snapshots.filter(s => s.sub_portfolio_id === spId).sort((a, b) => a.date.localeCompare(b.date))
+        );
+
+        // Keep running pointers/indices to avoid O(N^2) inner loops
+        const balanceIndices = new Array(sortedBalances.length).fill(0);
+        const snapshotIndices = new Array(sortedSnapshotsBySp.length).fill(0);
+
         return sortedDates.map(date => {
             let cash = 0;
-            Object.values(balances).forEach(history => {
-                const pastOrCurrent = history.filter(h => h.date <= date).sort((a, b) => a.date.localeCompare(b.date));
-                if (pastOrCurrent.length > 0) {
-                    cash += Number(pastOrCurrent[pastOrCurrent.length - 1].balance);
+            sortedBalances.forEach((history, i) => {
+                while (balanceIndices[i] < history.length - 1 && history[balanceIndices[i] + 1].date <= date) {
+                    balanceIndices[i]++;
+                }
+                if (history.length > 0 && history[balanceIndices[i]].date <= date) {
+                    cash += Number(history[balanceIndices[i]].balance);
                 }
             });
 
@@ -82,14 +98,12 @@ export default function Dashboard() {
             if (snapshotsOnDate.length > 0) {
                 portfolio = snapshotsOnDate.reduce((sum, s) => sum + Number(s.current_value_home_currency), 0);
             } else {
-                // Find latest snapshots before this date
-                const subPortfolioIds = Array.from(new Set(snapshots.map(s => s.sub_portfolio_id)));
-                subPortfolioIds.forEach(spId => {
-                    const pastSnapshots = snapshots
-                        .filter(s => s.sub_portfolio_id === spId && s.date < date)
-                        .sort((a, b) => a.date.localeCompare(b.date));
-                    if (pastSnapshots.length > 0) {
-                        portfolio += Number(pastSnapshots[pastSnapshots.length - 1].current_value_home_currency);
+                sortedSnapshotsBySp.forEach((spHistory, i) => {
+                    while (snapshotIndices[i] < spHistory.length - 1 && spHistory[snapshotIndices[i] + 1].date <= date) {
+                        snapshotIndices[i]++;
+                    }
+                    if (spHistory.length > 0 && spHistory[snapshotIndices[i]].date <= date) {
+                        portfolio += Number(spHistory[snapshotIndices[i]].current_value_home_currency);
                     }
                 });
             }


### PR DESCRIPTION
### 💡 What
Refactored the `useMemo` calculations for charting data in both `Accounts.tsx` and `Dashboard.tsx`. I extracted the array sorting out of the inner loop and replaced `filter().sort()` lookups with running pointers over pre-sorted history arrays. Also added a journal entry in `.jules/bolt.md` documenting this performance pattern.

### 🎯 Why
The previous logic repeatedly filtered and sorted balance history arrays for *every single chronological date point* mapped in the chart. In data-heavy systems, placing `.filter().sort()` inside `.map()` iterations turns an expected $O(N)$ evaluation into an $O(N^2 \log N)$ algorithm, which actively blocks the main thread and freezes the UI when generating large charts.

### 📊 Impact
Reduces chart data recalculation time from $O(N^2 \log N)$ to $O(N)$. For user accounts with a substantial history of daily balances and portfolio snapshots, this will eliminate main thread freezing and dramatically improve dashboard load times and interactive reactivity.

### 🔬 Measurement
Run `pnpm build` in the `frontend/` directory to verify standard builds pass. You can measure rendering speed on a test account with 1000+ historical balance data points to observe the elimination of rendering lag.

---
*PR created automatically by Jules for task [1981923172381543507](https://jules.google.com/task/1981923172381543507) started by @ivanleekk*