### PR TITLE
🎨 Palette: Improve accessibility of Input component

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-08 - Accessible Forms
+**Learning:** Proper association of helper texts and error messages with input elements using `aria-describedby` dynamically links the message ID and broadcasts error states using `aria-invalid`. This greatly improves accessibility for screen readers on interactive forms.
+**Action:** Always dynamically generate and link IDs when creating input/form components with helper/error text so `aria-describedby` can resolve appropriately.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -29,6 +29,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           id={inputId}
           disabled={disabled}
+          aria-invalid={error ? "true" : "false"}
+          aria-describedby={helperText ? `${inputId}-helper` : undefined}
           className={cn(
             "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
             {
@@ -41,6 +43,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         />
         {helperText && (
           <p
+            id={`${inputId}-helper`}
             className={cn("text-sm text-base-500", {
               "text-red-500": error && !disabled,
               "text-base-400": disabled,


### PR DESCRIPTION
💡 **What**: The UX enhancement added `aria-invalid` and `aria-describedby` attributes to the `Input` component.
🎯 **Why**: The user problem it solves is that screen readers did not previously announce the helper text or the error state of the input, making forms less accessible to users with visual impairments.
♿ **Accessibility**: Input components now dynamically associate helper text using `aria-describedby` and reflect error states using `aria-invalid`. This greatly improves the screen reader experience on interactive forms.

---
*PR created automatically by Jules for task [7575476906458400109](https://jules.google.com/task/7575476906458400109) started by @ivanleekk*