### PR TITLE
⚡ Bolt: Replace O(n^2 log n) chart data aggregation with O(n) single-pass hash map

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-09 - Time-series chart aggregation optimization
+**Learning:** Avoid nested `.filter().sort()` inside `.map()` loops when aggregating time-series data for charts. The previous code in `Accounts.tsx` was using an O(N^2 log N) approach, calculating running balances repeatedly for every single date in the chart which blocked the main thread on large datasets.
+**Action:** Use an O(N) single-pass approach instead: initialize running balances for each account, iterate through chronologically sorted events to update the running balances, and populate the chart data.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -95,18 +95,36 @@ export default function Accounts() {
     }
 
     // UPDATED: Now maps each account's balance to its name per date
+    // ⚡ Bolt: Replaced O(N^2 log N) filter().sort() inside map() with O(N) single-pass approach
     const aggregatedChartData = useMemo(() => {
         const allDatesSet = new Set<string>();
-        accounts.forEach(acc => acc.history.forEach(h => allDatesSet.add(h.date)));
+
+        // Map account IDs/names to their history for quick lookup
+        const historyMap: Record<string, Record<string, number>> = {};
+
+        accounts.forEach(acc => {
+            historyMap[acc.name] = {};
+            acc.history.forEach(h => {
+                allDatesSet.add(h.date);
+                historyMap[acc.name][h.date] = Number(h.balance_home_currency ?? h.balance);
+            });
+        });
 
         const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+
+        // Track running balances
+        const currentBalances: Record<string, number> = {};
+        accounts.forEach(acc => currentBalances[acc.name] = 0);
 
         return sortedDates.map(date => {
             const dataPoint: any = { date };
 
             accounts.forEach(acc => {
-                const lastBalRec = acc.history.filter(h => h.date <= date).sort((a, b) => b.date.localeCompare(a.date))[0];
-                dataPoint[acc.name] = lastBalRec ? Number(lastBalRec.balance_home_currency ?? lastBalRec.balance) : 0;
+                // Update running balance if there's a record for this date
+                if (historyMap[acc.name][date] !== undefined) {
+                    currentBalances[acc.name] = historyMap[acc.name][date];
+                }
+                dataPoint[acc.name] = currentBalances[acc.name];
             });
 
             return dataPoint;


### PR DESCRIPTION
💡 **What:** The `aggregatedChartData` useMemo hook in `Accounts.tsx` was optimized to use a single-pass hash map approach instead of nested `.filter().sort()` iterations inside a `.map()` block.
🎯 **Why:** The previous code was calculating the running balances over and over again for every date using an O(N^2 log N) algorithm, which would cause significant lag and block the main thread for large data sets.
📊 **Impact:** Reduces computation complexity from O(N^2 log N) to O(N). Improves page load times and prevents UI stutter when rendering large numbers of transactions.
🔬 **Measurement:** Running the `pnpm build` process checks that regressions weren't introduced. Running the chart data over a timeline of transactions will verify that it is identical as before, but computed in one pass.

---
*PR created automatically by Jules for task [1849397422402111443](https://jules.google.com/task/1849397422402111443) started by @ivanleekk*