### PR TITLE
🎨 Palette: Improve form input accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-09 - Improve form accessibility in Input component
+**Learning:** For users navigating forms using screen readers, it's vital to programmatically associate helper texts/error messages with input elements and distinctly broadcast valid/invalid states. Without explicit ARIA mappings, valuable contextual information and validation state fail to reach assistive technologies.
+**Action:** When building or modifying form inputs in the frontend, always dynamically map helper/error text using `aria-describedby` on the input element linking to an assigned `id` on the text element, and ensure error states trigger the `aria-invalid` property.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
     const generatedId = React.useId()
     const inputId = id || generatedId
+    const helperId = helperText ? `${inputId}-helper` : undefined
 
     return (
       <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           id={inputId}
           disabled={disabled}
+          aria-invalid={!!error}
+          aria-describedby={helperId}
           className={cn(
             "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
             {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         />
         {helperText && (
           <p
+            id={helperId}
             className={cn("text-sm text-base-500", {
               "text-red-500": error && !disabled,
               "text-base-400": disabled,


### PR DESCRIPTION
💡 What: Added `aria-describedby` and `aria-invalid` to the `Input` component.
🎯 Why: To properly associate helper/error text with the input element and broadcast error states for users relying on assistive technologies (screen readers).
📸 Before/After: Visuals remain unchanged, but the DOM now includes accurate ARIA mappings.
♿ Accessibility: Ensures that form validations and context are fully screen-reader compatible.

---
*PR created automatically by Jules for task [17518055768081690097](https://jules.google.com/task/17518055768081690097) started by @ivanleekk*