### PR TITLE
🎨 Palette: Improve Form Input Accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-05-10 - [Form Input Accessibility Enhancement]
+**Learning:** Helper texts and error messages need to be explicitly associated with their input fields using `aria-describedby` so screen readers can properly announce them. The error state also needs to be broadcasted dynamically using `aria-invalid`. This is critical for users relying on screen readers to understand form validation and instructions.
+**Action:** Always ensure that when building or modifying form components (like `Input.tsx`), an ID is generated for the helper text, linked to the input via `aria-describedby`, and the `aria-invalid` attribute is properly managed according to the error state.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
     const generatedId = React.useId()
     const inputId = id || generatedId
+    const helperId = `${inputId}-helper`
 
     return (
       <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           type={type}
           id={inputId}
           disabled={disabled}
+          aria-invalid={error ? "true" : undefined}
+          aria-describedby={helperText ? helperId : undefined}
           className={cn(
             "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
             {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         />
         {helperText && (
           <p
+            id={helperId}
             className={cn("text-sm text-base-500", {
               "text-red-500": error && !disabled,
               "text-base-400": disabled,


### PR DESCRIPTION
💡 **What:** Added `aria-describedby` to explicitly associate `helperText` with the `<input>` element, and added `aria-invalid` to dynamically broadcast the error state to screen readers.
🎯 **Why:** Users relying on screen readers need context to understand form validation and instructions. By linking the helper text explicitly and broadcasting error states dynamically, we significantly enhance the form filling experience for those users.
📸 **Before/After:** Not a visual change. This is entirely an accessibility (under the hood) enhancement.
♿ **Accessibility:** Form fields now properly broadcast their error states and any contextual guidance (helper text).

---
*PR created automatically by Jules for task [4604504256847642299](https://jules.google.com/task/4604504256847642299) started by @ivanleekk*