### PR TITLE
🎨 Palette: Form validation accessibility association

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-23 - Form Validation Accessibility Association
+**Learning:** When building reusable UI inputs, it's a common accessibility gap to have helper text or error messages visually adjacent but programmatically detached from the input. Screen readers won't announce the helper/error text when the input is focused unless explicitly linked.
+**Action:** Always map the input's `aria-describedby` dynamically to the ID of its helper/error text element. Additionally, use `aria-invalid={!!error}` so that the screen reader correctly announces the input's invalid state independently of the styling.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -8,9 +8,15 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
 }
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-    ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
+    ({ className, type, error, label, helperText, disabled, id, "aria-describedby": ariaDescribedBy, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = `${inputId}-helper`
+
+        const describedBy = [
+            helperText ? helperTextId : undefined,
+            ariaDescribedBy
+        ].filter(Boolean).join(" ") || undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +35,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={!!error}
+                    aria-describedby={describedBy}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +49,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
### 🎨 Palette: Form Validation Accessibility Association

**💡 What:** 
Added dynamic `aria-describedby` and `aria-invalid` attributes to the reusable `Input` component. Screen readers will now automatically announce helper text and error messages when the input is focused.

**🎯 Why:** 
Previously, helper text and error messages were visually adjacent to the input field, but they were not programmatically associated. When a user relying on a screen reader focused on an input field, they were completely blind to any crucial validation rules or active errors displayed right below it. This change closes that gap.

**♿ Accessibility Improvements:**
- Screen readers now independently announce `aria-invalid` if an error occurs.
- Screen readers now reliably announce validation instructions/errors via `aria-describedby` when the input is focused, maintaining parent-passed ARIA references.

---
*PR created automatically by Jules for task [12246542145661036537](https://jules.google.com/task/12246542145661036537) started by @ivanleekk*