### PR TITLE
⚡ Bolt: optimize chartData aggregation to O(N)

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+
+## 2025-05-12 - [O(N^2) mapping logic for chart data]
+**Learning:** Nested `.filter()`, `.reduce()` and `.find()` calls inside iterating loops for mapping time-series chart data can block the main thread by introducing an O(N^2) complexity on large datasets.
+**Action:** Always pre-group array data using Hash Maps (`new Map()`) outside the loop, and maintain running balances to avoid redundant iterations inside the mapping logic, allowing the logic to operate with an O(N) complexity.

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -81,39 +81,55 @@ export default function Dashboard() {
 
     const netWorth = currentCash + currentPortfolioValue;
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N * (A * H + S)) nested filtering and finding inside the date map
+    // with an O(N) single-pass approach that uses hash maps and running totals.
     // Aggregate historical data for the chart using real snapshots and carrying forward cash
     const chartData = useMemo(() => {
         const allDatesSet = new Set<string>();
-        snapshots.forEach(s => allDatesSet.add(s.date));
-        Object.values(balances).forEach(history => {
-            history.forEach(b => allDatesSet.add(b.date));
+
+        // Pre-group snapshots by date
+        const snapshotsByDate = new Map<string, number>();
+        snapshots.forEach(s => {
+            snapshotsByDate.set(s.date, (snapshotsByDate.get(s.date) || 0) + Number(s.current_value_home_currency));
+            allDatesSet.add(s.date);
+        });
+
+        // Pre-group balances by date
+        const balancesByDate = new Map<string, Array<{accId: string, balance: number}>>();
+        Object.entries(balances).forEach(([accId, history]) => {
+            history.forEach(b => {
+                const bArray = balancesByDate.get(b.date) || [];
+                bArray.push({accId, balance: Number(b.balance_home_currency ?? b.balance)});
+                balancesByDate.set(b.date, bArray);
+                allDatesSet.add(b.date);
+            });
         });
 
         const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
+        let runningTotalCash = 0;
         
         const rawData = sortedDates.map(date => {
             // Update latest balances for any account that has a record on THIS date
-            Object.entries(balances).forEach(([accId, history]) => {
-                const balOnDate = history.find(b => b.date === date);
-                if (balOnDate) {
-                    accountLatestBalances.set(accId, Number(balOnDate.balance_home_currency ?? balOnDate.balance));
-                }
-            });
-
-            const currentTotalCash = Array.from(accountLatestBalances.values()).reduce((sum, val) => sum + val, 0);
+            const balsOnDate = balancesByDate.get(date);
+            if (balsOnDate) {
+                balsOnDate.forEach(({accId, balance}) => {
+                    const prevBal = accountLatestBalances.get(accId) || 0;
+                    runningTotalCash += (balance - prevBal);
+                    accountLatestBalances.set(accId, balance);
+                });
+            }
             
             // Get portfolio snapshots for this date
-            const currentTotalPortfolio = snapshots
-                .filter(s => s.date === date)
-                .reduce((sum, s) => sum + Number(s.current_value_home_currency), 0);
+            const currentTotalPortfolio = snapshotsByDate.get(date) || 0;
 
             return {
                 date,
-                netWorth: currentTotalCash + currentTotalPortfolio,
-                cash: currentTotalCash,
+                netWorth: runningTotalCash + currentTotalPortfolio,
+                cash: runningTotalCash,
                 portfolio: currentTotalPortfolio
             };
         });


### PR DESCRIPTION
💡 **What:** Refactored the `chartData` useMemo hook in `frontend/src/pages/Dashboard/Dashboard.tsx` to use an $O(N)$ single-pass algorithm with hash maps and running totals, rather than $O(N^2)$ nested filtering and mapping loops.
🎯 **Why:** The original approach of using nested `.find`, `.filter`, and `.reduce` inside the `sortedDates.map` blocked the main UI thread as the dataset size expanded, significantly degrading performance.
📊 **Impact:** Reduces time complexity of computing chart data from $O(N \times (A \times H + S))$ to $O(N)$.
🔬 **Measurement:** Verify by loading the Dashboard page and observing the execution time of the `chartData` computation on a large account/transaction dataset without freezing the UI.

---
*PR created automatically by Jules for task [3722110628838826773](https://jules.google.com/task/3722110628838826773) started by @ivanleekk*