### PR TITLE
🎨 Palette: Add aria-describedby and aria-invalid to Input component

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Form Input Accessibility: Dynamic ARIA Binding
+**Learning:** Hardcoding static IDs or missing explicit association between inputs and helper texts leads to screen readers failing to provide full context on form elements.
+**Action:** When building or modifying form inputs in the future, always dynamically associate helper texts and error messages with the input element using `aria-describedby` based on unique auto-generated IDs and broadcast error states via `aria-invalid`.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -12,6 +12,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
         const generatedId = React.useId()
         const inputId = id || generatedId
 
+        const helperTextId = helperText ? `${inputId}-description` : undefined
+
         return (
             <div className="flex w-full flex-col gap-1.5">
                 {label && (
@@ -29,6 +31,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={!!error}
+                    aria-describedby={helperTextId}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +45,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
💡 What: Add dynamic `aria-describedby` and `aria-invalid` bindings to the `<Input />` UI component.
🎯 Why: Screen readers fail to provide full context on form elements if helper texts are not correctly and explicitly associated with the input they belong to, or if error states are visually conveyed but not properly broadcasted to assistive tech.
📸 Before/After: No visual changes! This is a structural markup enhancement.
♿ Accessibility: Improved semantic linking of form labels and helper texts using native ARIA attributes.

---
*PR created automatically by Jules for task [17282964442871418468](https://jules.google.com/task/17282964442871418468) started by @ivanleekk*