### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in scheduler secret verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-14 - [Timing Attack in Secret Verification]
+**Vulnerability:** The internal API scheduler secret verification was using `!=` for string comparison.
+**Learning:** String comparison with `==` or `!=` may exit early, revealing information about the expected string character by character through measuring response times. This allows attackers to brute-force a secret token efficiently.
+**Prevention:** Always use `secrets.compare_digest` when verifying security tokens, secrets, or passwords to perform a constant-time comparison, preventing timing attacks.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: The internal API scheduler secret verification (`verify_scheduler_secret` in `backend/src/routers/internal.py`) was using `!=` for string comparison.

🎯 **Impact**: String comparison with `==` or `!=` may exit early upon finding the first mismatched character. This allows attackers to measure the response time and brute-force the expected secret character by character efficiently, potentially leading to unauthorized execution of internal tasks.

🔧 **Fix**: Updated `verify_scheduler_secret` to use `secrets.compare_digest()`, which performs a constant-time comparison and is resilient against timing attacks.

✅ **Verification**:
1. Reviewed `backend/src/routers/internal.py` to ensure `secrets` is imported and `secrets.compare_digest` is used correctly.
2. The change is isolated and does not affect the rest of the application.
3. Tests (`pnpm test`, `pnpm lint`, `pnpm build` on the frontend, and `pytest` on the backend) have been executed to ensure no regressions. Unrelated test failures pre-date this change.

---
*PR created automatically by Jules for task [12477831837403253960](https://jules.google.com/task/12477831837403253960) started by @ivanleekk*