### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -30,6 +30,7 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             >
                 <button
                     onClick={onClose}
+                    aria-label="Close dialog"
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >
                     <X className="h-5 w-5" />

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -281,7 +281,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button variant="ghost" aria-label="Remove member" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}

--- a/frontend/src/pages/Transactions/Transactions.tsx
+++ b/frontend/src/pages/Transactions/Transactions.tsx
@@ -608,6 +608,7 @@ export default function Transactions() {
                                         <Button
                                             variant="ghost"
                                             size="sm"
+                                            aria-label="Delete transaction"
                                             className="text-base-400 hover:text-red-600 hover:bg-red-50 h-8 w-8 p-0"
                                             onClick={() => handleDelete(item)}
                                             disabled={isDeleting === item.id}


### PR DESCRIPTION
### 💡 What
Added `aria-label` attributes to three icon-only buttons across the application:
- **Dialog Close Button:** `aria-label="Close dialog"`
- **Household Member Remove Button:** `aria-label="Remove member"`
- **Transaction Delete Button:** `aria-label="Delete transaction"`

### 🎯 Why
Icon-only buttons rely entirely on visual context to convey meaning. Users who are visually impaired or using screen readers cannot discern the function of these buttons without an accessible text label.

### 📸 Before/After
*(No visual changes - purely an HTML attribute addition for assistive tech).*

### ♿ Accessibility
This micro-UX improvement ensures that screen readers will now read out "Close dialog", "Remove member", or "Delete transaction" when users focus on these previously unlabelled `<button>` elements, fulfilling basic WCAG guidelines for interactive elements.

---
*PR created automatically by Jules for task [6811954461587887617](https://jules.google.com/task/6811954461587887617) started by @ivanleekk*