### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability and information exposure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-17 - Prevent Timing Attacks in Token Verification
+**Vulnerability:** Comparing scheduler secrets (or tokens) using standard equality (`==` or `!=`) exposes the application to timing attacks, as string comparison typically returns early on the first mismatched character.
+**Learning:** We need to ensure that secret/token comparisons take constant time regardless of whether the string matches or fails, and where it fails.
+**Prevention:** Always use `secrets.compare_digest(a, b)` instead of standard string equality for comparing tokens, secrets, or passwords.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if not x_scheduler_secret or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The backend was previously vulnerable to timing attacks during scheduler token verification due to standard string equality comparisons. In addition, internal server errors were leaking explicit exception stack traces to external callers in the snapshot routing logic.
🎯 **Impact**: A malicious user could brute-force the internal token by evaluating string comparison latency. They could also intentionally crash or manipulate the backend to extract sensitive server information via raw exception outputs.
🔧 **Fix**: Substituted standard equality checks with constant-time validations (`secrets.compare_digest`) to prevent timing inference. Validated that `x_scheduler_secret` header inputs are present before comparison to avoid `NoneType` crashes. Sanitized the 500 error exception handler to output generic, safe messages instead of dynamic exceptions. Added a journal entry per guidelines.
✅ **Verification**: Run `uv run pytest` in the backend ensuring standard operations pass. Verify that passing an incorrect token results in 403 Forbidden with uniform timing, and omitting the token responds safely. Verify 500 exceptions output "Internal server error occurred".

---
*PR created automatically by Jules for task [16044961718855789433](https://jules.google.com/task/16044961718855789433) started by @ivanleekk*