### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styles to Dialog close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Missing ARIA Labels on Icon-only UI components
+**Learning:** Common UI components like the Dialog close button only render a `<X />` icon without text. Without an `aria-label`, screen readers only announce these as "button", rendering them inaccessible. Furthermore, they are often missing explicit focus states (`focus-visible`) which harms keyboard navigation.
+**Action:** Always add descriptive `aria-label`s (e.g. `aria-label="Close dialog"`) to icon-only buttons and ensure proper focus visibility using Tailwind's `focus-visible:ring-2` to support both screen readers and keyboard users.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What**: Added an `aria-label`, explicit `type="button"`, and visible keyboard focus states (`focus-visible`) to the icon-only close button within the generic `Dialog` component.

🎯 **Why**: Previously, the close button simply rendered an `<X />` icon, making it inaccessible to screen readers (which would just announce "button"). Furthermore, it lacked explicit focus states which harmed keyboard users. The `type="button"` addition prevents any unintended form submission if the `Dialog` is placed inside a form.

📸 **Before/After**: Visually identical for mouse users, but keyboard users will now see a primary colored focus ring when tabbing.

♿ **Accessibility**: 
- Added `aria-label="Close dialog"` allowing screen readers to accurately read the button's action.
- Added `focus-visible:ring-2` to visually indicate focus for keyboard users.
- `type="button"` fixes potential accidental submits.
- Created `.jules/palette.md` to document this critical accessibility learning for future components.

---
*PR created automatically by Jules for task [18372619577890339365](https://jules.google.com/task/18372619577890339365) started by @ivanleekk*