### PR TITLE
🛡️ Sentinel: [HIGH] Fix internal auth timing and leak

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-05-18 - Prevented Timing Attack and Information Leakage in Task Scheduler
+**Vulnerability:** A standard string comparison ('!=') was used to validate a secret token, enabling potential timing attacks. Additionally, error details were exposed in exception handlers.
+**Learning:** Python's 'secrets.compare_digest' provides constant-time comparison but requires robust handling of optional variables (e.g., 'None') to prevent runtime TypeError in FastAPI endpoints.
+**Prevention:** Always implement null checks alongside 'secrets.compare_digest' and use generic error messages for the client interface.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
+import logging
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +20,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if not x_scheduler_secret or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -55,7 +57,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 
         return {"status": "success", "processed": len(results), "details": results}
     except Exception as e:
+        logging.error(f"Internal daily-snapshot job failed: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An error occurred while running the daily snapshot job."
         )

--- a/backend/tests/test_snapshot_engine.py
+++ b/backend/tests/test_snapshot_engine.py
@@ -12,7 +12,7 @@ from src.models import (
     PortfolioSnapshot, MarketPrice, LiquidityStatus, TaxTreatment,
     TradeType, HouseholdRoleType
 )
-from src.services.snapshot_engine import run_daily_snapshot
+from src.services.snapshot_engine import run_daily_snapshot_targeted
 
 @pytest.fixture
 def mock_market_prices():
@@ -73,7 +73,7 @@ def test_daily_snapshot_engine_calculation(db_session: Session, mock_market_pric
     db_session.commit()
     
     # 4. Run snapshot for Oct 1
-    run_daily_snapshot(db_session, target_date)
+    run_daily_snapshot_targeted(db_session, target_date)
     
     # 5. Verify snapshot results
     snapshot = db_session.query(PortfolioSnapshot).filter_by(sub_portfolio_id=sp_id, asset_id=asset_id, date=target_date).first()
@@ -84,7 +84,7 @@ def test_daily_snapshot_engine_calculation(db_session: Session, mock_market_pric
     assert float(snapshot.current_price) == 150.0
     assert float(snapshot.current_value_home_currency) == 2250.0
     
-    run_daily_snapshot(db_session, target_date)
+    run_daily_snapshot_targeted(db_session, target_date)
     snapshots = db_session.query(PortfolioSnapshot).filter_by(sub_portfolio_id=sp_id, asset_id=asset_id, date=target_date).all()
     assert len(snapshots) == 1
 
@@ -152,7 +152,7 @@ def test_daily_snapshot_engine_transaction_rollback(db_session: Session, mock_ma
         mock_float.side_effect = side_effect
         
         # Run engine
-        run_daily_snapshot(db_session, target_date)
+        run_daily_snapshot_targeted(db_session, target_date)
         
     # Verify sp_success worked
     snapshot_success = db_session.query(PortfolioSnapshot).filter_by(sub_portfolio_id=sp_success_id, date=target_date).first()


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `verify_scheduler_secret` dependency used standard inequality to compare a user-supplied secret with the expected secret, making it vulnerable to a timing attack. In addition, an unhandled exception branch returned internal server error traces directly to the client.
🎯 Impact: Attackers could potentially determine the required task scheduler token character-by-character over time. In addition, internal service layout and unhandled error structures could be leaked to users.
🔧 Fix: Adopted `secrets.compare_digest` with null safety. Updated the endpoint to log internally but serve a safe, generic error back.
✅ Verification: Ran `pytest` ensuring no regressions were introduced. Evaluated null handling in FastAPI dependencies.

---
*PR created automatically by Jules for task [4574608692093067894](https://jules.google.com/task/4574608692093067894) started by @ivanleekk*