### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styles to Dialog close button

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 What
Added `type="button"`, `aria-label="Close"`, and `focus-visible` styles to the icon-only close button in `Dialog.tsx`.

🎯 Why
Icon-only buttons are inaccessible to screen readers without an ARIA label. They also need a clear visual focus indicator for keyboard users, and explicitly declaring `type="button"` prevents unintended form submissions if the Dialog happens to be rendered inside a `<form>`.

📸 Before/After
Before: Icon-only button without label, focus styles, or type.
After: Accessible button with screen reader support and keyboard focus ring.

♿ Accessibility
- Added `aria-label="Close"`
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500`
- Added `type="button"`

---
*PR created automatically by Jules for task [2308123296455004585](https://jules.google.com/task/2308123296455004585) started by @ivanleekk*