### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sort with O(N) reduce for finding latest balance

### DIFF
--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -105,10 +105,14 @@ export default function Accounts() {
         }).format(value);
     }
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N log N) sorting with O(N) single-pass reduce to find the latest balance.
+    // This is critical because it's called inside the sortedAccounts sort callback.
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+        const last = history.reduce((latest, current) =>
+            current.date.localeCompare(latest.date) > 0 ? current : latest
+        );
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,11 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt Performance Optimization:
+                // Replaced O(N log N) sorting with O(N) single-pass reduce to find the latest balance.
+                const last = history.reduce((latest, current) =>
+                    current.date.localeCompare(latest.date) > 0 ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });


### PR DESCRIPTION
💡 **What:** Replaced the `[...history].sort(...)` operation with a single-pass `Array.prototype.reduce()` to find the latest balance record based on the date.

🎯 **Why:** Sorting a copied array just to find the extremum (most recent date) is computationally expensive, $O(N \log N)$. In `Accounts.tsx`, this operation was happening inside a sorting callback (`sortedAccounts`), which compounds the performance hit. Changing it to an $O(N)$ single-pass `reduce` prevents main-thread blocking as historical datasets grow.

📊 **Impact:** Reduces time complexity for finding the current balance from $O(N \log N)$ to $O(N)$. Speeds up table sorting and chart data aggregation when handling accounts with many historical entries.

🔬 **Measurement:** Verify by navigating to the Dashboard and Accounts pages with a large number of historical balance records and observe smoother rendering and sorting. Tests `pnpm test` and linters pass.

---
*PR created automatically by Jules for task [18325764101410390350](https://jules.google.com/task/18325764101410390350) started by @ivanleekk*