### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sorting with O(N) reduce for finding latest dates

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -52,18 +52,23 @@ export default function Dashboard() {
         }).format(value)
     }
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N log N) array sorting with O(N) single-pass reduce to find the latest date.
     const currentCash = useMemo(() => {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
         return total;
     }, [balances]);
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N log N) date sorting with O(N) single-pass reduce to find the maximum date string.
     const currentPortfolioValue = useMemo(() => {
         if (snapshots.length === 0) return 0;
 
@@ -73,10 +78,11 @@ export default function Dashboard() {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
-        if (sortedDates.length === 0) return 0;
+        const keys = Object.keys(snapshotsByDate);
+        if (keys.length === 0) return 0;
 
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        const latestDate = keys.reduce((latest, current) => current > latest ? current : latest);
+        return snapshotsByDate[latestDate];
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -235,8 +235,10 @@ export default function Portfolio() {
                 }))
                 .filter(item => !startDate || item.date >= startDate);
 
-            const sortedDates = Array.from(dailyEquity.keys()).sort((a, b) => a.localeCompare(b));
-            const latestDate = sortedDates[sortedDates.length - 1];
+            // ⚡ Bolt Performance Optimization:
+            // Replaced O(N log N) sorting to find the latest date with an O(N) single-pass reduce.
+            const keys = Array.from(dailyEquity.keys());
+            const latestDate = keys.length > 0 ? keys.reduce((latest, current) => current > latest ? current : latest) : "";
             const latestSnaps = snaps.filter(s => {
                 const dateKey = typeof s.date === 'string' ? s.date.split('T')[0] : s.date;
                 return dateKey === latestDate;


### PR DESCRIPTION
💡 What: Replaced array sorting (`sort()`) with single-pass array reduction (`reduce()`) when evaluating the latest dates in `Dashboard.tsx` (for calculating `currentCash` and `currentPortfolioValue`) and `Portfolio.tsx` (for evaluating `calculateFromSnapshots`).

🎯 Why: Sorting an entire array only to extract the maximum element is a $O(N \log N)$ operation that creates unnecessary garbage (through array copying). A single-pass `reduce` achieves the exact same result in $O(N)$ time with constant memory, preventing potential main-thread blocking when scaling the history arrays.

📊 Impact: Reduces computational complexity from $O(N \log N)$ to $O(N)$ and eliminates shallow array cloning (`[...history]`) when finding extreme values in render loops.

🔬 Measurement: Verifiable via code review and maintaining test suite success.

---
*PR created automatically by Jules for task [8469699072564749299](https://jules.google.com/task/8469699072564749299) started by @ivanleekk*