### PR TITLE
⚡ Bolt: [performance improvement] O(N) hash map optimization for frontend chart aggregations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+
+## 2026-05-21 - [O(N) Hash Map Optimization for Time-Series Aggregation]
+**Learning:** In React components rendering historical charts (e.g., Dashboard, Accounts), nesting array methods like `.filter().reduce()` or `.find()` inside a `.map()` loop over all unique dates creates an O(N * M) performance bottleneck that blocks the main thread on large datasets.
+**Action:** Pre-compute lookup hash maps for values (e.g. `portfolioByDate` or `balanceUpdatesByDate`) and iterate once over the sorted dates, applying running totals in O(1) time to achieve a single-pass O(N) aggregation.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -118,9 +118,20 @@ export default function Accounts() {
     // ⚡ Bolt Performance Optimization:
     // Replaced O(D * A * H log H) nested filtering and sorting inside the date map
     // with an O(N) single-pass approach that tracks running balances.
+    // Further optimized to avoid .find() lookup by using a pre-computed hash map for balance updates.
     const aggregatedChartData = useMemo(() => {
         const allDatesSet = new Set<string>();
-        accounts.forEach(acc => acc.history.forEach(h => allDatesSet.add(h.date)));
+        const balanceUpdatesByDate = new Map<string, Map<string, number>>();
+
+        accounts.forEach(acc => {
+            acc.history.forEach(h => {
+                allDatesSet.add(h.date);
+                if (!balanceUpdatesByDate.has(h.date)) {
+                    balanceUpdatesByDate.set(h.date, new Map());
+                }
+                balanceUpdatesByDate.get(h.date)!.set(acc.id, Number(h.balance_home_currency ?? h.balance));
+            });
+        });
 
         const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
 
@@ -130,14 +141,16 @@ export default function Accounts() {
         return sortedDates.map(date => {
             const dataPoint: any = { date };
 
-            accounts.forEach(acc => {
-                // Find if there's an exact record for this date
-                const balOnDate = acc.history.find(h => h.date === date);
-                if (balOnDate) {
-                    accountLatestBalances.set(acc.id, Number(balOnDate.balance_home_currency ?? balOnDate.balance));
-                }
+            // Apply updates for this specific date
+            const updatesToday = balanceUpdatesByDate.get(date);
+            if (updatesToday) {
+                updatesToday.forEach((newBal, accId) => {
+                    accountLatestBalances.set(accId, newBal);
+                });
+            }
 
-                // Use the carried-forward balance (or 0 if none yet)
+            // Populate data point with current running balances for all accounts
+            accounts.forEach(acc => {
                 dataPoint[acc.name] = accountLatestBalances.get(acc.id) || 0;
             });
 

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -83,32 +83,47 @@ export default function Dashboard() {
 
     // Aggregate historical data for the chart using real snapshots and carrying forward cash
     const chartData = useMemo(() => {
+        // ⚡ Bolt: O(N) single-pass optimization for chart data aggregation.
+        // Replaced nested array operations (.filter().reduce() and .find() inside .map())
+        // with pre-computed hash maps and running totals to prevent main-thread blocking.
+
         const allDatesSet = new Set<string>();
-        snapshots.forEach(s => allDatesSet.add(s.date));
-        Object.values(balances).forEach(history => {
-            history.forEach(b => allDatesSet.add(b.date));
+        const portfolioByDate = new Map<string, number>();
+
+        snapshots.forEach(s => {
+            allDatesSet.add(s.date);
+            portfolioByDate.set(s.date, (portfolioByDate.get(s.date) || 0) + Number(s.current_value_home_currency));
+        });
+
+        const balanceUpdatesByDate = new Map<string, Map<string, number>>();
+        Object.entries(balances).forEach(([accId, history]) => {
+            history.forEach(b => {
+                allDatesSet.add(b.date);
+                if (!balanceUpdatesByDate.has(b.date)) {
+                    balanceUpdatesByDate.set(b.date, new Map());
+                }
+                balanceUpdatesByDate.get(b.date)!.set(accId, Number(b.balance_home_currency ?? b.balance));
+            });
         });
 
         const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
+        let currentTotalCash = 0;
         
         const rawData = sortedDates.map(date => {
-            // Update latest balances for any account that has a record on THIS date
-            Object.entries(balances).forEach(([accId, history]) => {
-                const balOnDate = history.find(b => b.date === date);
-                if (balOnDate) {
-                    accountLatestBalances.set(accId, Number(balOnDate.balance_home_currency ?? balOnDate.balance));
-                }
-            });
+            // Apply any balance updates for this date in O(1)
+            const updatesToday = balanceUpdatesByDate.get(date);
+            if (updatesToday) {
+                updatesToday.forEach((newBal, accId) => {
+                    const oldBal = accountLatestBalances.get(accId) || 0;
+                    currentTotalCash += (newBal - oldBal);
+                    accountLatestBalances.set(accId, newBal);
+                });
+            }
 
-            const currentTotalCash = Array.from(accountLatestBalances.values()).reduce((sum, val) => sum + val, 0);
-            
-            // Get portfolio snapshots for this date
-            const currentTotalPortfolio = snapshots
-                .filter(s => s.date === date)
-                .reduce((sum, s) => sum + Number(s.current_value_home_currency), 0);
+            const currentTotalPortfolio = portfolioByDate.get(date) || 0;
 
             return {
                 date,


### PR DESCRIPTION
💡 **What:** 
Replaced O(D * A * H) nested array operations (using `.find()`, `.filter()`, and `.reduce()` inside `.map()` loops over all dates) with an O(N) single-pass approach in `Dashboard.tsx` and `Accounts.tsx`. We pre-compute hash maps (`Map`) for fast O(1) lookups and track running balances incrementally across sorted dates.

🎯 **Why:** 
Aggregating historical balances and portfolio data dynamically in a render loop via nested iteration quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow, particularly on views loading dense datasets like the Dashboard or Accounts views.

📊 **Impact:** 
Significantly reduces React re-rendering time for large datasets. Transforms chart data aggregation complexity from `O(Dates × Accounts × History)` to effectively `O(N)` linear time.

🔬 **Measurement:** 
Run `pnpm build` and verify that the frontend functions normally. The UI logic is preserved completely while yielding massive performance improvements for users with long trade histories and multiple accounts.

---
*PR created automatically by Jules for task [18099456179660641435](https://jules.google.com/task/18099456179660641435) started by @ivanleekk*