### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) array sorts with O(N) single-pass scans

### DIFF
--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -105,10 +105,15 @@ export default function Accounts() {
         }).format(value);
     }
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N log N) array copy and sort with an O(N) single-pass reduce
+    // to find the latest balance, significantly improving performance inside render loops
+    // and sort callbacks.
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+        const last = history.reduce((latest, current) =>
+            current.date > latest.date ? current : latest
+        );
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -52,31 +52,39 @@ export default function Dashboard() {
         }).format(value)
     }
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced O(N log N) array copy and sort inside loop with an O(N) single-pass reduce
+    // to find the latest balance, significantly improving performance.
     const currentCash = useMemo(() => {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
         return total;
     }, [balances]);
 
+    // ⚡ Bolt Performance Optimization:
+    // Replaced Object.keys(snapshotsByDate).sort() (O(N log N)) with an O(N) loop
+    // to track and find the latest date while building the snapshotsByDate map.
     const currentPortfolioValue = useMemo(() => {
         if (snapshots.length === 0) return 0;
 
         // Group snapshots by date and find the latest date
         const snapshotsByDate: Record<string, number> = {};
+        let latestDate = snapshots[0].date;
         snapshots.forEach(s => {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
+            if (s.date > latestDate) {
+                latestDate = s.date;
+            }
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
-        if (sortedDates.length === 0) return 0;
-
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        return snapshotsByDate[latestDate] || 0;
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -235,8 +235,16 @@ export default function Portfolio() {
                 }))
                 .filter(item => !startDate || item.date >= startDate);
 
-            const sortedDates = Array.from(dailyEquity.keys()).sort((a, b) => a.localeCompare(b));
-            const latestDate = sortedDates[sortedDates.length - 1];
+            // ⚡ Bolt Performance Optimization:
+            // Replaced O(N log N) Array.from(dailyEquity.keys()).sort()
+            // with an O(N) loop over keys to find the latestDate, saving unnecessary allocations and sorting.
+            let latestDate = "";
+            for (const date of dailyEquity.keys()) {
+                if (!latestDate || date > latestDate) {
+                    latestDate = date;
+                }
+            }
+
             const latestSnaps = snaps.filter(s => {
                 const dateKey = typeof s.date === 'string' ? s.date.split('T')[0] : s.date;
                 return dateKey === latestDate;


### PR DESCRIPTION
💡 What: Replaced several instances where arrays or object keys were copied and sorted (O(N log N)) simply to find the item with the latest date. These have been replaced with single-pass `reduce` or `for` loops (O(N)).
🎯 Why: Sorting entire arrays just to find a single extremum (maximum date) is an anti-pattern that creates unnecessary array copies, memory allocations, and computational overhead, particularly when these operations run inside React render loops or `useMemo` hooks with large datasets.
📊 Impact: Reduces main thread blocking time during re-renders by eliminating unnecessary O(N log N) sorting overhead. Time complexity for these specific operations goes from O(N log N) to O(N).
🔬 Measurement: Verify by interacting with the Dashboard and Portfolio charts with extensive historical data to notice reduced UI lag. Tests and linters pass successfully.

---
*PR created automatically by Jules for task [12635688809773783798](https://jules.google.com/task/12635688809773783798) started by @ivanleekk*