### PR TITLE
🎨 Palette: [UX improvement] Link Input helper text and error state for screen readers

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = `${inputId}-helper-text`
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={error ? "true" : undefined}
+                    aria-describedby={helperText ? helperTextId : undefined}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
💡 **What:** Added `aria-invalid` and `aria-describedby` properties to the core `Input` component, dynamically associating the input field with its corresponding error/helper text via a generated ID.
🎯 **Why:** To ensure that screen readers accurately announce form validation states and read out accompanying helper text when an input is focused, improving overall form accessibility.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Form fields with errors or helper text now correctly alert assistive technologies, adhering strictly to WCAG guidelines for programmatic association.

---
*PR created automatically by Jules for task [13773173988957406957](https://jules.google.com/task/13773173988957406957) started by @ivanleekk*