### PR TITLE
🎨 Palette: [UX improvement] Fix Dialog close button accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What:** Improved the UX and accessibility of the generic close button within the main Dialog component by adding standard attributes and focus states.
🎯 **Why:** Icon-only buttons require an `aria-label` for screen reader legibility, `type="button"` to avoid accidental form submissions in case the dialog contains a form, and `focus-visible` styling to indicate focus during keyboard navigation.
📸 **Before/After:** The button now exhibits a blue focus ring (`focus-visible:ring-2 focus-visible:ring-primary-500`) when tabbed onto. 
♿ **Accessibility:** Added an `aria-label` for screen readers and customized visual focus indication.

---
*PR created automatically by Jules for task [9079227199064949050](https://jules.google.com/task/9079227199064949050) started by @ivanleekk*