### PR TITLE
⚡ Bolt: [Performance] Replace O(N log N) sorts with O(N) reduce for extremums

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,6 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+## 2024-05-18 - Single Extremum Finding
+**Learning:** Using `[...array].sort((a,b) => ...)[last]` to find a single extremum (like the latest date or maximum balance) inside of loops or component render cycles (e.g. `useMemo` dependencies) creates unnecessary GC pressure from array cloning and degrades performance to `O(N log N)`.
+**Action:** Always replace this anti-pattern with a single-pass `Array.prototype.reduce()` to find the maximum/minimum value, improving the time complexity to `O(N)` and avoiding memory allocation.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -107,8 +107,14 @@ export default function Accounts() {
 
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+
+        // ⚡ Bolt Performance Optimization:
+        // Replaced O(N log N) sorting with O(N) single-pass reduce to find the latest balance.
+        // This is heavily called inside useMemo dependencies and render loops.
+        const last = history.reduce((latest, current) =>
+            current.date > latest.date ? current : latest
+        , history[0]);
+
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,11 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt Performance Optimization:
+                // Replaced O(N log N) sorting with O(N) single-pass reduce to find the latest balance.
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                , history[0]);
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -235,8 +235,12 @@ export default function Portfolio() {
                 }))
                 .filter(item => !startDate || item.date >= startDate);
 
-            const sortedDates = Array.from(dailyEquity.keys()).sort((a, b) => a.localeCompare(b));
-            const latestDate = sortedDates[sortedDates.length - 1];
+            // ⚡ Bolt Performance Optimization:
+            // Replaced O(N log N) sorting with O(N) single-pass reduce to find the latest date.
+            const latestDate = Array.from(dailyEquity.keys()).reduce((latest, current) =>
+                current > latest ? current : latest
+            , "");
+
             const latestSnaps = snaps.filter(s => {
                 const dateKey = typeof s.date === 'string' ? s.date.split('T')[0] : s.date;
                 return dateKey === latestDate;


### PR DESCRIPTION
### 💡 What
Replaced the `[...array].sort((a,b) => ...)[last]` anti-pattern with a single-pass `Array.prototype.reduce()` across three files (`Accounts.tsx`, `Dashboard.tsx`, `Portfolio.tsx`) to find the latest balance or date.

### 🎯 Why
The previous implementation cloned and sorted entire arrays just to find a single maximum value (the latest date/balance). This was especially detrimental because it was used inside loops and `useMemo` hooks, causing unnecessary memory allocation (GC pressure) and operating at `O(N log N)` instead of the optimal `O(N)`.

### 📊 Impact
*   Reduces time complexity for finding the latest record from `O(N log N)` to `O(N)`.
*   Eliminates array allocation overhead during `useMemo` recalculations.
*   Speeds up filtering when computing dashboard or portfolio snapshot data.

### 🔬 Measurement
Run `pnpm test --run` to ensure all historical data mapping still groups perfectly by the correct latest dates. Time to interactive (TTI) when loading large dashboard datasets will decrease.

---
*PR created automatically by Jules for task [77203142657904982](https://jules.google.com/task/77203142657904982) started by @ivanleekk*