### PR TITLE
🎨 Palette: [UX improvement] Enhance Dialog close button accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 What: 
- Explicitly set `type="button"` on the Dialog close `<button>`
- Added `aria-label="Close dialog"` for the `X` icon
- Appended `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to `className`

🎯 Why: 
- Prevents unintended form submissions when the Dialog encapsulates forms
- Provides necessary screen reader text for an icon-only button
- Ensures keyboard users have a clear visual focus indicator

📸 Before/After: 
*(Visual changes only apparent when navigating via keyboard/Tab, standard display unchanged)*

♿ Accessibility:
- Better screen reader context via `aria-label`
- Improved keyboard usability via standard focus styling

---
*PR created automatically by Jules for task [2702735177204244966](https://jules.google.com/task/2702735177204244966) started by @ivanleekk*