### PR TITLE
⚡ Bolt: [performance improvement] Replace O(N log N) sort with O(N) reduce for extremums

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+
+## 2024-05-18 - Avoid O(N log N) Sorting for Extremums inside React Hooks
+**Learning:** In React components dealing with large financial datasets (like `Dashboard.tsx` and `Accounts.tsx`), operations that find a maximum or minimum value (e.g., finding the "latest date" or "most recent balance") using array copying and sorting (`[...arr].sort(...)` or `Object.keys(obj).sort(...)`) cause severe performance degradation, especially when placed inside loops or array sort callbacks, resulting in O(N^2 log N) performance hits.
+**Action:** Always replace O(N log N) sorting with a single-pass O(N) `Array.prototype.reduce()` to find extreme values (maximums, minimums, latest entries), drastically improving render times for dense dashboards.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -107,8 +107,15 @@ export default function Accounts() {
 
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+
+        // ⚡ Bolt Performance Optimization:
+        // Replaced O(N log N) sorting with O(N) reduce to find the latest balance.
+        // This is crucial because this function is called inside the `sortedAccounts`
+        // array sort callback, previously turning an O(M log M) operation into O(M log M * N log N).
+        const last = history.reduce((latest, current) => {
+            return current.date > latest.date ? current : latest;
+        });
+
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,11 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt Performance Optimization:
+                // Replaced O(N log N) sorting with O(N) reduce to find the latest balance.
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
@@ -73,10 +76,16 @@ export default function Dashboard() {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
-        if (sortedDates.length === 0) return 0;
+        const dateKeys = Object.keys(snapshotsByDate);
+        if (dateKeys.length === 0) return 0;
 
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        // ⚡ Bolt Performance Optimization:
+        // Replaced O(N log N) sorting with O(N) reduce to find the latest date.
+        const latestDate = dateKeys.reduce((latest, current) =>
+            current > latest ? current : latest
+        );
+
+        return snapshotsByDate[latestDate];
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;


### PR DESCRIPTION
💡 **What:**
Replaced `[...history].sort(...)` and `Object.keys(snapshotsByDate).sort(...)` with a single pass `Array.prototype.reduce()` to find extremums (the latest date/balance).
Added inline comments explaining the performance improvement strategy.

🎯 **Why:**
Using shallow copies and `.sort()` to find a single maximum element (e.g., the latest history entry) incurs unnecessary O(N log N) overhead. In `Accounts.tsx`, this sorting was performed inside the `sortedAccounts` array sort callback, effectively making the time complexity `O(M log M * N log N)`, causing significant CPU blocking for accounts with dense historical data. In `Dashboard.tsx`, this sorting occurred during the `currentCash` and `currentPortfolioValue` memoization logic.

📊 **Impact:**
Reduces the time complexity of finding the latest records from O(N log N) to O(N). For large datasets, this completely eliminates main-thread CPU spikes associated with sorting arrays and drastically speeds up the Accounts page load and Dashboard re-renders.

🔬 **Measurement:**
No visual or functional regressions. Verified via full frontend test suite (`pnpm test`), successful build compilation (`pnpm build`), and standard linting. Memory allocations and GC pressure are also reduced due to avoiding intermediate array copying (`[...history]`).

---
*PR created automatically by Jules for task [11198248286854841373](https://jules.google.com/task/11198248286854841373) started by @ivanleekk*