### PR TITLE
🛡️ Sentinel: [HIGH] Fix internal API timing attack and info disclosure

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-27 - FastAPI Optional Dependencies and Secrets Comparison
+**Vulnerability:** FastAPIs `Header(None)` and `secrets.compare_digest` type mismatch. A timing attack vulnerability existed where string comparison `!=` was used for `x_scheduler_secret != expected_secret`. However, `x_scheduler_secret` uses `Header(None)`, meaning it can be `None`.
+**Learning:** `secrets.compare_digest` requires both arguments to be strings (or bytes). If a header is optional (`None`), passing it to `compare_digest` raises a `TypeError`, leading to an internal server error (HTTP 500) rather than a clean authorization error (HTTP 401/403).
+**Prevention:** Always explicitly check for `None` before passing optional FastAPI dependencies (like `Header(None)`) into `secrets.compare_digest()`. Example: `if token is None or not secrets.compare_digest(token, expected_secret):`.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred during the scheduled job"
         )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability:
1. The internal `/tasks/daily-snapshot` endpoint used standard string comparison (`!=`) to verify the `SCHEDULER_SECRET`, which is vulnerable to timing attacks.
2. The same endpoint exposed internal application details by returning the raw exception string (`str(e)`) in a 500 error response.

🎯 Impact:
1. An attacker could theoretically deduce the scheduler secret via timing analysis.
2. Internal system paths or database errors could be leaked to the client.

🔧 Fix: 
- Updated `verify_scheduler_secret` to use `secrets.compare_digest` and safely handled `None` inputs.
- Updated `scheduled_snapshot_job` exception handler to return a generic error message.

✅ Verification: 
- Ran `uv run ruff check` to ensure syntax is clean.
- Ran backend test suite to ensure the changes did not break core functionality.

---
*PR created automatically by Jules for task [4833349488347768939](https://jules.google.com/task/4833349488347768939) started by @ivanleekk*