### PR TITLE
🎨 Palette: Improve screen reader support for Input helper text and errors

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperId = helperText ? `${inputId}-helper` : undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={error ? true : undefined}
+                    aria-describedby={helperId}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
### 💡 What
Updated the `<Input>` UI component to dynamically map its helper text to the input field using `aria-describedby` and reflect its error state using `aria-invalid`. 

### 🎯 Why
Previously, form helper texts and error messages were visually grouped but not programmatically linked to the input. Screen readers would not read the help text when the input was focused, which violated accessibility guidelines.

### 📸 Before/After
No visual changes.

### ♿ Accessibility
- Added `aria-describedby` to the `<input>` element so screen readers read the helper text alongside the input name.
- Added `aria-invalid` to the `<input>` element to announce when the input has an error.
- Linked the helper `<p>` tag using an automatically generated `id`.

---
*PR created automatically by Jules for task [12486645872056787995](https://jules.google.com/task/12486645872056787995) started by @ivanleekk*