### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability and information disclosure in internal endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-21 - [FastAPI Timing Attacks & Info Disclosure]
+**Vulnerability:** FastApi endpoints verifying custom auth headers used naive string equality (`!=`), and broad exception handlers returned `str(e)` in 500 errors to the client.
+**Learning:** Naive equality operators in python are susceptible to timing attacks allowing attackers to guess secret tokens. Exposing full Exception traces (`str(e)`) via HTTPException exposes internal application structure and data.
+**Prevention:** Always use `secrets.compare_digest` for security comparisons and ensure it receives non-None types. Never pass raw exception strings to the client; log them internally instead.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
+import logging
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +20,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -55,7 +57,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 
         return {"status": "success", "processed": len(results), "details": results}
     except Exception as e:
+        logging.error(f"Error during daily snapshot job: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Internal server error during snapshot job"
         )


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `/internal/tasks/daily-snapshot` endpoint checked the `X-Scheduler-Secret` header using a naive string equality (`!=`) comparison, which is vulnerable to timing attacks. Additionally, the broad exception handler caught all `Exception`s and returned their raw string representations (`str(e)`) back to the client, leading to potential information disclosure of internal system errors.
🎯 **Impact**: An attacker could potentially deduce the scheduler secret via timing analysis. Further, triggering an internal error could leak sensitive internal logic or state to a malicious actor.
🔧 **Fix**: 
- Replaced the string equality check with `secrets.compare_digest()` to ensure constant-time comparison, guarding against `None` inputs to prevent 500 errors.
- Modified the exception handler to log the raw exception string internally via `logging.error()` and return a generic "Internal server error" string to the client.
✅ **Verification**: Verified the tests run completely. The vulnerability and its fixes are standard Python security best practices.

---
*PR created automatically by Jules for task [9388128409667956132](https://jules.google.com/task/9388128409667956132) started by @ivanleekk*