### PR TITLE
🎨 Palette: [UX improvement] Add accessibility to Dialog close button

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 What:
Added accessibility attributes and keyboard focus styles to the `Dialog` component's icon-only close button.

🎯 Why:
To improve accessibility for screen readers and keyboard-only users, ensuring the button's purpose is clear and its focused state is visible, while also preventing unintended form submissions if the Dialog is used within a form context.

📸 Before/After:
Before: The close button was a simple icon without a label and lacked clear focus indicators.
After: The button now announces its purpose to screen readers, explicitly acts as a button, and shows a visible ring when focused via keyboard.

♿ Accessibility:
- Added `aria-label="Close dialog"` for screen readers.
- Added `type="button"` to prevent default form submission behavior.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` for keyboard focus state.

---
*PR created automatically by Jules for task [18372330825348413232](https://jules.google.com/task/18372330825348413232) started by @ivanleekk*