### PR TITLE
🎨 Palette: [UX] Improve accessibility and focus states for Dialog close button

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What**: Improved the accessibility and usability of the `Dialog` close button.
🎯 **Why**: The close button in the `Dialog` component consisted solely of a `<X />` icon. It lacked an accessible name for screen readers, could trigger accidental form submissions if placed within a `<form>`, and its keyboard focus state was not clearly visible according to our design tokens.
📸 **Before/After**: See attached video/screenshot (verified locally via Playwright script).
♿ **Accessibility**: Added `aria-label="Close dialog"` for screen readers, added `type="button"`, and applied `focus-visible` Tailwind classes (`focus-visible:ring-2 focus-visible:ring-primary-500`) to ensure clear keyboard navigation visibility.

---
*PR created automatically by Jules for task [10441643283020536030](https://jules.google.com/task/10441643283020536030) started by @ivanleekk*