### PR TITLE
⚡ Bolt: [performance improvement] Replace localeCompare and sorting extremums

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+
+## 2025-02-28 - Optimizing Array Extremum lookups
+**Learning:** Using `reduce` to find extremums inside `useMemo` hooks is a safe optimization, but requires checking for `.length > 0` to prevent `TypeError: Reduce of empty array with no initial value` exceptions when data is empty.
+**Action:** Always wrap `.reduce()` implementations intended for extremum finding with ternary operators checking for `.length > 0` or provide safe initial values if returning objects.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -107,8 +107,10 @@ export default function Accounts() {
 
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+        // ⚡ Bolt: Replaced O(N log N) sort + copy with O(N) reduce to find latest balance
+        const last = history.reduce((latest, current) =>
+            current.date > latest.date ? current : latest
+        );
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)
@@ -122,7 +124,8 @@ export default function Accounts() {
         const allDatesSet = new Set<string>();
         accounts.forEach(acc => acc.history.forEach(h => allDatesSet.add(h.date)));
 
-        const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+        // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+        const sortedDates = Array.from(allDatesSet).sort((a, b) => a > b ? 1 : a < b ? -1 : 0);
 
         // Track the latest balance for each account to carry forward
         const accountLatestBalances = new Map<string, number>();
@@ -599,7 +602,8 @@ export default function Accounts() {
                                         <tbody className="divide-y divide-base-100 dark:divide-base-800">
                                             {historyAccount.history
                                                 .filter(h => h.is_manual)
-                                                .sort((a, b) => b.date.localeCompare(a.date))
+                                                // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+                                                .sort((a, b) => b.date > a.date ? 1 : b.date < a.date ? -1 : 0)
                                                 .map((h) => (
                                                     <tr key={h.id} className="group hover:bg-base-50 dark:hover:bg-base-800/50 transition-colors">
                                                         <td className="px-2 py-3 font-medium text-base-900 dark:text-base-50">

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,10 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt: Replaced O(N log N) sort + copy with O(N) reduce to find latest balance
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
@@ -73,10 +75,13 @@ export default function Dashboard() {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
-        if (sortedDates.length === 0) return 0;
+        const dates = Object.keys(snapshotsByDate);
+        if (dates.length === 0) return 0;
 
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        // ⚡ Bolt: Replaced O(N log N) sort with O(N) reduce to find the latest date
+        const latestDate = dates.reduce((latest, current) => current > latest ? current : latest);
+
+        return snapshotsByDate[latestDate];
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;
@@ -89,7 +94,8 @@ export default function Dashboard() {
             history.forEach(b => allDatesSet.add(b.date));
         });
 
-        const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+        // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+        const sortedDates = Array.from(allDatesSet).sort((a, b) => a > b ? 1 : a < b ? -1 : 0);
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
@@ -141,7 +147,8 @@ export default function Dashboard() {
             binned.set(key, item);
         });
 
-        return Array.from(binned.values()).sort((a, b) => a.date.localeCompare(b.date));
+        // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+        return Array.from(binned.values()).sort((a, b) => a.date > b.date ? 1 : a.date < b.date ? -1 : 0);
     }, [balances, snapshots, timeframe, startDate]);
 
     if (!activeHousehold) {
@@ -362,7 +369,8 @@ export default function Dashboard() {
                 <CardContent>
                     <div className="space-y-4">
                         {transactions.length > 0 ? (
-                            transactions.slice(0, 5).sort((a, b) => b.date.localeCompare(a.date)).map((tx) => (
+                            // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+                            transactions.slice(0, 5).sort((a, b) => b.date > a.date ? 1 : b.date < a.date ? -1 : 0).map((tx) => (
                                 <div key={tx.id} className="flex items-center justify-between border-b border-base-100 dark:border-base-800 pb-4 last:border-0 last:pb-0">
                                     <div>
                                         <p className="font-medium text-base-900 dark:text-base-50">{tx.description || 'Transaction'}</p>

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -182,7 +182,8 @@ export default function Portfolio() {
 
             return Array.from(binned.entries())
                 .filter(([date]) => !startDate || date >= startDate)
-                .sort((a, b) => a[0].localeCompare(b[0]))
+                // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+                .sort((a, b) => a[0] > b[0] ? 1 : a[0] < b[0] ? -1 : 0)
                 .map(([date, equity]) => ({ date, equity }));
         };
 
@@ -228,15 +229,17 @@ export default function Portfolio() {
             });
 
             const history = Array.from(dailyEquity.entries())
-                .sort((a, b) => a[0].localeCompare(b[0]))
+                // ⚡ Bolt: Replaced localeCompare with standard relational operators for faster date sorting
+                .sort((a, b) => a[0] > b[0] ? 1 : a[0] < b[0] ? -1 : 0)
                 .map(([date, equity]) => ({
                     date,
                     equity
                 }))
                 .filter(item => !startDate || item.date >= startDate);
 
-            const sortedDates = Array.from(dailyEquity.keys()).sort((a, b) => a.localeCompare(b));
-            const latestDate = sortedDates[sortedDates.length - 1];
+            const dates = Array.from(dailyEquity.keys());
+            // ⚡ Bolt: Replaced O(N log N) sort with O(N) reduce to find the latest date
+            const latestDate = dates.length > 0 ? dates.reduce((latest, current) => current > latest ? current : latest) : undefined;
             const latestSnaps = snaps.filter(s => {
                 const dateKey = typeof s.date === 'string' ? s.date.split('T')[0] : s.date;
                 return dateKey === latestDate;


### PR DESCRIPTION
**💡 What**:
1. Replaced `String.prototype.localeCompare` with standard relational operators (`>` and `<`) for sorting ISO format date strings across `Accounts.tsx`, `Dashboard.tsx`, and `Portfolio.tsx`.
2. Replaced `Array.prototype.sort()[array.length - 1]` with `Array.prototype.reduce()` to find the latest date/balance in `useMemo` hooks. 

**🎯 Why**: 
`localeCompare` is heavily dependent on the engine's Intl implementation and is orders of magnitude slower than basic string comparison operations. Standard relational operators on ISO-8601 strings guarantee correct lexicographical ordering without the overhead.
Finding a single extremum (min/max) by copying an array and sorting it involves $O(N \log N)$ complexity and unnecessary memory allocation, whereas a single pass `.reduce()` gives an $O(N)$ execution path. 

**📊 Impact**: 
Eliminated unnecessary memory allocations and redundant $O(N \log N)$ compute cycles on large date arrays by turning them into $O(N)$ cycles. Reduces computation overhead during React `useMemo` renders when users have significant account/transaction history arrays.

**🔬 Measurement**:
Running `pnpm test` and `pnpm lint` confirms that logic continues to operate properly without regressions. All sorting functionality operates identically to previous implementations.

---
*PR created automatically by Jules for task [14254827551000491031](https://jules.google.com/task/14254827551000491031) started by @ivanleekk*