### PR TITLE
🎨 Palette: [UX improvement] Improve Dialog Close Button Accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
### 💡 What
Added `type="button"`, an `aria-label="Close dialog"`, and explicit `focus-visible` Tailwind classes to the icon-only Close button in the shared `Dialog` component (`frontend/src/components/ui/Dialog.tsx`).

### 🎯 Why
Icon-only buttons are invisible to screen readers without ARIA labels. Furthermore, the Close button lacked clear visual focus states when navigating via keyboard (tabbing). Adding these attributes ensures the component meets basic accessibility standards and prevents accidental form submissions if the Dialog is used within a form.

### 📸 Before/After
- **Before:** No screen reader context, no visible ring on tab focus.
- **After:** "Close dialog" read aloud by screen readers, and a clear primary-colored focus ring appears on keyboard focus.

### ♿ Accessibility
- Added `aria-label="Close dialog"` for screen reader announcements.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to make the keyboard focus state explicit.
- Added `type="button"` to ensure it isn't treated as a submit button when used in form contexts.

---
*PR created automatically by Jules for task [18030896151888725763](https://jules.google.com/task/18030896151888725763) started by @ivanleekk*