### PR TITLE
🎨 Palette: [UX improvement] Improve form input accessibility

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = helperText ? `${inputId}-helper-text` : undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={error ? "true" : undefined}
+                    aria-describedby={helperTextId}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
💡 **What:** 
Added `aria-invalid` to dynamically broadcast form input error states and `aria-describedby` to programmatically associate `helperText` content directly to the input element in the shared `Input.tsx` UI component.

🎯 **Why:** 
When an input field has an error or contains helper text instructions, screen readers need to read out that information when the user focuses on the input. Relying only on visual proximity or color changes is not enough for users utilizing assistive technologies.

📸 **Before/After:**
- **Before:** Form validation errors relied mostly on visual cues (red border/text). Screen readers would only announce the input label.
- **After:** Errors announce themselves automatically ("invalid entry"), and context hints provided in `helperText` are read out contextually as users type.

♿ **Accessibility:** 
- Enhances WCAG compliance for forms by utilizing `aria-describedby` properly.
- Broadcasts real-time invalid states to assistive technologies utilizing `aria-invalid`.

---
*PR created automatically by Jules for task [14838582850432451346](https://jules.google.com/task/14838582850432451346) started by @ivanleekk*