### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack vulnerability in scheduler secret comparison

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-06-02 - Prevent Timing Attacks in Header Secrets
+**Vulnerability:** Comparing sensitive headers (like secrets) with `!=` allows for timing attacks, and raw exceptions leaked internal state.
+**Learning:** Always use `secrets.compare_digest` for comparing secrets, handling `None` first. Also never leak `str(e)` in HTTP exceptions.
+**Prevention:** Utilize standard secure constant-time comparison methods and generic error messages.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +55,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Internal server error during snapshot processing"
         )


### PR DESCRIPTION
## 🚨 Severity: HIGH

## 💡 Vulnerability
1. **Timing Attack:** The `SCHEDULER_SECRET` header was being compared using a simple `!=` operator, which is vulnerable to timing attacks. This could allow an attacker to guess the secret character by character by measuring the response time.
2. **Information Leakage:** The exception handler in `scheduled_snapshot_job` was returning `str(e)` directly in the `HTTPException` detail, which could leak internal server state or database errors to the client.

## 🎯 Impact
- An attacker could potentially bypass the scheduler secret protection and trigger internal snapshot jobs.
- An attacker could gain insights into the internal architecture or data structures by forcing errors and reading the raw exception messages.

## 🔧 Fix
1. Updated `verify_scheduler_secret` in `backend/src/routers/internal.py` to use `secrets.compare_digest` for constant-time comparison, ensuring that the input is not `None` before comparison.
2. Updated the exception handler in `scheduled_snapshot_job` to return a generic "Internal server error during snapshot processing" message instead of the raw exception.

## ✅ Verification
1. Run `pnpm lint` and `uv run ruff check` to ensure no formatting or linting errors.
2. Run backend tests using `uv run pytest` (requires a running PostgreSQL instance configured for testing).

---
*PR created automatically by Jules for task [12041751893944512638](https://jules.google.com/task/12041751893944512638) started by @ivanleekk*