### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Timing Attack and Information Disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - Information Disclosure and Timing Attack in Daily Snapshot Endpoint
+**Vulnerability:** The internal `/tasks/daily-snapshot` endpoint had two vulnerabilities: it leaked detailed exception strings to the client in HTTP 500 responses (`detail=str(e)`), potentially exposing sensitive database or internal state information, and it compared the `X-Scheduler-Secret` header using a simple equality check (`!=`), which is susceptible to timing attacks.
+**Learning:** Even internal endpoints need strict error sanitization and secure secret comparison. Optional headers like `Header(None)` require explicit `None` checks before using functions like `secrets.compare_digest` to prevent runtime `TypeError`s.
+**Prevention:** Always use `secrets.compare_digest` for secret/token comparisons and never expose `str(e)` in HTTP responses; use generic error messages instead.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred during daily snapshot"
         )


### PR DESCRIPTION
🚨 **Severity:** CRITICAL

💡 **Vulnerability:**
The internal endpoint for daily snapshots (`/tasks/daily-snapshot`) had two significant security issues:
1. **Timing Attack Vulnerability:** The scheduler secret (provided via the `X-Scheduler-Secret` header) was compared using the `!=` operator, which short-circuits. This allows an attacker to potentially brute-force the secret by measuring the response time.
2. **Information Disclosure:** If an exception occurred during the snapshot execution, the raw error string (`str(e)`) was directly passed to the `HTTPException` detail. This could leak sensitive internal database structures or server state information to anyone triggering the endpoint.

🎯 **Impact:**
- An attacker could discover the scheduler secret via timing analysis and invoke unauthorized snapshot updates.
- Internal error stack traces could reveal backend implementation details, making it easier to craft targeted attacks.

🔧 **Fix:**
- Imported the `secrets` module and updated `verify_scheduler_secret` to use `secrets.compare_digest()` for constant-time comparison.
- Added a `None` check for `x_scheduler_secret` (since it is an optional `Header(None)`) before calling `compare_digest()` to prevent `TypeError`s.
- Replaced `detail=str(e)` in the broad exception handler with a generic error message (`"An internal error occurred during daily snapshot"`).

✅ **Verification:**
- Ran `uv run ruff check` and `uv run pytest --ignore=tests/test_snapshot_engine.py` to ensure syntax correctness and test passing.

---
*PR created automatically by Jules for task [252464089411270538](https://jules.google.com/task/252464089411270538) started by @ivanleekk*