### PR TITLE
🎨 Palette: [UX improvement] Improve Dialog close button accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
**💡 What:**
Added missing accessibility attributes and visible focus states to the generic `Dialog` component's close button.

**🎯 Why:**
The close button in the `Dialog` component consists only of an `<X />` icon. Without an `aria-label`, screen readers could not announce its purpose. Additionally, it lacked `type="button"`, which could cause accidental form submissions if the dialog was embedded within a `<form>`. Finally, it was missing `focus-visible` styles, making keyboard navigation difficult for users relying on visual focus indicators.

**📸 Before/After:**
*(Visual functionality remains the same for mouse users, but keyboard users now see a clear blue primary focus ring when tabbing to the close button, as verified in screenshots).*

**♿ Accessibility:**
- Added `aria-label="Close dialog"` to the `<button>` for screen reader context.
- Set `type="button"` to prevent default form submission behavior.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to provide a clear, standardized focus ring for keyboard navigation.

---
*PR created automatically by Jules for task [7187921039272356223](https://jules.google.com/task/7187921039272356223) started by @ivanleekk*