### PR TITLE
⚡ Bolt: O(N) Extremum finding & Fast string comparison

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,8 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt: Replace O(N log N) copy/sort with O(N) reduce for extremum finding
+                const last = history.reduce((max, current) => current.date > max.date ? current : max);
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
@@ -73,10 +73,12 @@ export default function Dashboard() {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
+        const sortedDates = Object.keys(snapshotsByDate);
         if (sortedDates.length === 0) return 0;
 
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        // ⚡ Bolt: O(N) reduce for max date
+        const latestDate = sortedDates.reduce((max, current) => current > max ? current : max);
+        return snapshotsByDate[latestDate];
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;
@@ -89,7 +91,8 @@ export default function Dashboard() {
             history.forEach(b => allDatesSet.add(b.date));
         });
 
-        const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+        // ⚡ Bolt: Fast date string comparison
+        const sortedDates = Array.from(allDatesSet).sort((a, b) => a < b ? -1 : a > b ? 1 : 0);
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
@@ -141,7 +144,8 @@ export default function Dashboard() {
             binned.set(key, item);
         });
 
-        return Array.from(binned.values()).sort((a, b) => a.date.localeCompare(b.date));
+        // ⚡ Bolt: Fast date string comparison
+        return Array.from(binned.values()).sort((a, b) => a.date < b.date ? -1 : a.date > b.date ? 1 : 0);
     }, [balances, snapshots, timeframe, startDate]);
 
     if (!activeHousehold) {
@@ -362,7 +366,8 @@ export default function Dashboard() {
                 <CardContent>
                     <div className="space-y-4">
                         {transactions.length > 0 ? (
-                            transactions.slice(0, 5).sort((a, b) => b.date.localeCompare(a.date)).map((tx) => (
+                            // ⚡ Bolt: Fast date string comparison
+                            transactions.slice(0, 5).sort((a, b) => b.date < a.date ? -1 : b.date > a.date ? 1 : 0).map((tx) => (
                                 <div key={tx.id} className="flex items-center justify-between border-b border-base-100 dark:border-base-800 pb-4 last:border-0 last:pb-0">
                                     <div>
                                         <p className="font-medium text-base-900 dark:text-base-50">{tx.description || 'Transaction'}</p>

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -182,7 +182,8 @@ export default function Portfolio() {
 
             return Array.from(binned.entries())
                 .filter(([date]) => !startDate || date >= startDate)
-                .sort((a, b) => a[0].localeCompare(b[0]))
+                /* ⚡ Bolt: Fast date string comparison */
+                .sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
                 .map(([date, equity]) => ({ date, equity }));
         };
 
@@ -228,15 +229,17 @@ export default function Portfolio() {
             });
 
             const history = Array.from(dailyEquity.entries())
-                .sort((a, b) => a[0].localeCompare(b[0]))
+                /* ⚡ Bolt: Fast date string comparison */
+                .sort((a, b) => a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0)
                 .map(([date, equity]) => ({
                     date,
                     equity
                 }))
                 .filter(item => !startDate || item.date >= startDate);
 
-            const sortedDates = Array.from(dailyEquity.keys()).sort((a, b) => a.localeCompare(b));
-            const latestDate = sortedDates[sortedDates.length - 1];
+            // ⚡ Bolt: Replace O(N log N) copy/sort with O(N) reduce for extremum finding
+            const keys = Array.from(dailyEquity.keys());
+            const latestDate = keys.length > 0 ? keys.reduce((max, current) => current > max ? current : max) : undefined;
             const latestSnaps = snaps.filter(s => {
                 const dateKey = typeof s.date === 'string' ? s.date.split('T')[0] : s.date;
                 return dateKey === latestDate;


### PR DESCRIPTION
💡 What: Replaced `[...array].sort((a,b) => localeCompare).pop()` patterns with a single-pass `Array.prototype.reduce()` to find maximum dates/balances. Also swapped slow `localeCompare` string sorting for ISO dates with standard fast relational operators (`<` and `>`).

🎯 Why: Calling `.sort()` on arrays to find a single max element is `O(N log N)` and involves creating array copies and doing many unnecessary comparisons. Using `localeCompare` adds extra localization overhead for perfectly standard ISO format dates. This combination blocks the main thread excessively when `N` grows.

📊 Impact: Shifts maximum element finding from `O(N log N)` down to a single pass `O(N)`, completely avoiding array copying and the massive runtime overhead of `localeCompare`.

🔬 Measurement: Review frontend test run speed or profile CPU usage when switching dashboard views with hundreds of history events.

---
*PR created automatically by Jules for task [4545750545585531253](https://jules.google.com/task/4545750545585531253) started by @ivanleekk*