### PR TITLE
⚡ Bolt: [performance improvement] Replace sorting with reduce for extremum finding

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2024-05-18 - Time-Series Chart Data Aggregation
 **Learning:** In a dashboard or analytics heavy app, computing running balances or aggregating time-series data dynamically in a render loop via nested filters/sorts (e.g. `arr.map(() => accounts.map(() => history.filter().sort()[0]))`) quickly becomes a catastrophic main-thread bottleneck, causing the UI to freeze as historical dataset sizes grow (e.g. `O(D * A * H log H)`).
 **Action:** When aggregating multi-dimensional time-series data for chart render loops, always use an O(N) single-pass approach: first extract and sort all unique dates (once), then iterate chronologically over those dates using hash maps to track running state variables (like `accountLatestBalances`). This avoids doing heavy array operations recursively on every data point.
+
+## 2024-05-19 - Extremum Finding Optimization
+**Learning:** Using `[...array].sort((a,b) => ...)` to find a single max or min value (like the most recent balance or date) inside a React `useMemo` or loop is highly inefficient. It creates an unnecessary shallow copy, taking O(N) memory, and takes O(N log N) time, which scales poorly when called frequently across multiple accounts.
+**Action:** Always use an O(N) approach like `array.reduce()` or a standard for-loop to find a single extremum value instead of creating a copy and sorting.

--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -107,8 +107,11 @@ export default function Accounts() {
 
     const getCurrentBalanceDetails = (history: BalanceResponse[]) => {
         if (history.length === 0) return { balance: 0, balanceHome: 0 };
-        const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-        const last = sorted[sorted.length - 1];
+        // ⚡ Bolt Performance Optimization:
+        // Replaced O(N log N) sorting with O(N) reduce to find the latest balance.
+        const last = history.reduce((latest, current) =>
+            current.date > latest.date ? current : latest
+        );
         return {
             balance: Number(last.balance),
             balanceHome: Number(last.balance_home_currency ?? last.balance)

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -56,8 +56,11 @@ export default function Dashboard() {
         let total = 0;
         Object.values(balances).forEach(history => {
             if (history.length > 0) {
-                const sorted = [...history].sort((a, b) => a.date.localeCompare(b.date));
-                const last = sorted[sorted.length - 1];
+                // ⚡ Bolt Performance Optimization:
+                // Replaced O(N log N) sorting with O(N) reduce to find the latest balance.
+                const last = history.reduce((latest, current) =>
+                    current.date > latest.date ? current : latest
+                );
                 total += Number(last.balance_home_currency ?? last.balance);
             }
         });
@@ -73,10 +76,16 @@ export default function Dashboard() {
             snapshotsByDate[s.date] = (snapshotsByDate[s.date] || 0) + Number(s.current_value_home_currency);
         });
 
-        const sortedDates = Object.keys(snapshotsByDate).sort((a, b) => a.localeCompare(b));
-        if (sortedDates.length === 0) return 0;
+        const dates = Object.keys(snapshotsByDate);
+        if (dates.length === 0) return 0;
 
-        return snapshotsByDate[sortedDates[sortedDates.length - 1]];
+        // ⚡ Bolt Performance Optimization:
+        // Replaced O(N log N) sorting with O(N) reduce to find the latest date string.
+        const latestDate = dates.reduce((latest, current) =>
+            current > latest ? current : latest
+        );
+
+        return snapshotsByDate[latestDate];
     }, [snapshots]);
 
     const netWorth = currentCash + currentPortfolioValue;


### PR DESCRIPTION
💡 **What:** Replaced `[...array].sort((a,b) => ...)` with `array.reduce(...)` when finding the latest date or latest balance in `Dashboard.tsx` and `Accounts.tsx`.

🎯 **Why:** Creating a shallow copy and doing a full sort is `O(N log N)` time complexity and has an `O(N)` memory overhead. Since the logic only needs the maximum value (a single extremum), an `O(N)` `reduce` operation without copying the array is significantly faster and more memory efficient. This is particularly important because these calculations happen inside `useMemo` hooks that traverse multiple accounts and historical data points on the main dashboard.

📊 **Impact:** Reduces time complexity from `O(N log N)` to `O(N)` and eliminates unnecessary `O(N)` memory allocations per calculation. This results in faster React render cycles and reduced garbage collection overhead when viewing the Dashboard or Accounts pages with large datasets.

🔬 **Measurement:** Verified by running `pnpm test`, `pnpm build`, and `pnpm lint` to ensure the logic and core functionality are strictly preserved. Metrics on the Dashboard will render measurably faster for users with extensive historical portfolio data.

---
*PR created automatically by Jules for task [7952371096439072326](https://jules.google.com/task/7952371096439072326) started by @ivanleekk*