### PR TITLE
🎨 Palette: Improve button accessibility (ARIA labels & focus states)

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>

--- a/frontend/src/components/ui/TimeframeSelector.tsx
+++ b/frontend/src/components/ui/TimeframeSelector.tsx
@@ -40,11 +40,11 @@ export function TimeframeSelector() {
     return (
         <div className="flex bg-base-100 dark:bg-base-900/50 p-1 rounded-lg border border-base-200 dark:border-base-800">
             {options.map((option) => (
-                <button
+                <button type="button"
                     key={option}
                     onClick={() => handleSelect(option)}
                     className={cn(
-                        "px-3 py-1 text-xs font-medium rounded-md transition-all",
+                        "px-3 py-1 text-xs font-medium rounded-md transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500",
                         activeTimeframe === option
                             ? "bg-white dark:bg-base-700 text-base-900 dark:text-base-50 shadow-sm"
                             : "text-base-500 dark:text-base-400 hover:text-base-700 dark:hover:text-base-200"

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -281,7 +281,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button type="button" aria-label="Remove member" variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto focus-visible:ring-2 focus-visible:ring-primary-500">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}

--- a/frontend/src/pages/Transactions/Transactions.tsx
+++ b/frontend/src/pages/Transactions/Transactions.tsx
@@ -606,9 +606,11 @@ export default function Transactions() {
                                             {formatAmount(item.type, item.amountAccount, item.currencyAccount)}
                                         </span>
                                         <Button
+                                            type="button"
+                                            aria-label="Delete transaction"
                                             variant="ghost"
                                             size="sm"
-                                            className="text-base-400 hover:text-red-600 hover:bg-red-50 h-8 w-8 p-0"
+                                            className="text-base-400 hover:text-red-600 hover:bg-red-50 h-8 w-8 p-0 focus-visible:ring-2 focus-visible:ring-primary-500"
                                             onClick={() => handleDelete(item)}
                                             disabled={isDeleting === item.id}
                                         >


### PR DESCRIPTION
💡 **What:** 
Added `aria-label`s and `type="button"` to icon-only interactive buttons, and ensured consistent `focus-visible` styling for keyboard navigation across several key UI components (Dialog, Transactions, Households, TimeframeSelector).

🎯 **Why:** 
Screen readers announce icon-only buttons simply as "button" if no `aria-label` is present, making the action confusing. Furthermore, missing `focus-visible` styles make it difficult for keyboard users to track their current focus. Finally, native `<button>` elements within forms without an explicit `type` default to `type="submit"`, potentially causing unintended form submissions.

📸 **Before/After:**
*(Visual changes are limited to focus states during keyboard navigation. No layout or styling regressions introduced, verified via screenshot).*

♿ **Accessibility:** 
- Improved screen reader context for delete, remove, and close actions.
- Improved keyboard navigation tracking via clear focus rings.
- Prevented accidental form submissions.

---
*PR created automatically by Jules for task [12339170934171438073](https://jules.google.com/task/12339170934171438073) started by @ivanleekk*