### PR TITLE
🎨 Palette: [UX improvement] Improve Dialog close button accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
**💡 What:** 
Added `type="button"`, an `aria-label`, and `focus-visible` styling to the close ('X') button in the generic `Dialog` component.

**🎯 Why:**
The close button was an icon-only button without an accessible name, making its purpose unclear to screen reader users. Additionally, it lacked visible focus indicators for keyboard navigation and was missing `type="button"`, which could trigger unintended form submissions when the dialog is used inside a form.

**📸 Before/After:**
*(See attached screenshot from the verification workflow demonstrating the prominent blue focus ring when navigating via keyboard.)*

**♿ Accessibility:**
- Added `aria-label="Close dialog"` for screen readers.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to make keyboard focus clearly visible.
- Added `type="button"` to ensure it behaves consistently and predictably.

---
*PR created automatically by Jules for task [12505562176991956478](https://jules.google.com/task/12505562176991956478) started by @ivanleekk*