### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix timing attack and info disclosure in internal tasks

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-06-06 - [Timing Attack and Info Disclosure in Internal Tasks]
+**Vulnerability:** The internal snapshot scheduling endpoint `backend/src/routers/internal.py` was vulnerable to timing attacks due to the use of a simple string inequality (`!=`) operator to compare the `x_scheduler_secret` header. Furthermore, an information disclosure vulnerability was present in the exception block, exposing the internal exception details (`detail=str(e)`).
+**Learning:** We need to handle `None` checks properly when utilizing `secrets.compare_digest` in FastAPI endpoints where the Header can be missing, and ensure that raw exception messages are not logged out to users or via generic HTTP exceptions.
+**Prevention:** Always use constant-time comparison `secrets.compare_digest` for secret tokens, ensuring type handling (checking for falsy values like `None`), and avoid returning `str(e)` inside FastAPI HTTP exceptions.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if not x_scheduler_secret or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,6 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred while processing the snapshot job."
+        # Sentinel: Replaced str(e) to prevent info disclosure
         )


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix timing attack and info disclosure in internal tasks

**Severity:** CRITICAL
**Vulnerability:** 
1. The scheduler secret verification in `backend/src/routers/internal.py` used the basic `!=` operator, leaving it vulnerable to timing attacks that could allow an attacker to guess the secret.
2. The exception handler for the `scheduled_snapshot_job` returned the internal exception message via `str(e)`, potentially leaking sensitive backend details.

**Impact:** 
- An attacker could potentially bypass the internal scheduling API's authentication and force arbitrary job executions.
- Information disclosure could reveal internal system information, giving attackers insight into the app's architecture and error states.

**Fix:** 
1. Imported the `secrets` module and updated `verify_scheduler_secret` to use `secrets.compare_digest()` for constant-time string comparison while carefully checking for `None`.
2. Updated `scheduled_snapshot_job` to return a generic "An internal error occurred" error message, preventing stack trace/exception leakage.

**Verification:** 
- Used `uv run ruff check` to ensure syntax formatting.
- Executed `uv run pytest --ignore=tests/test_snapshot_engine.py` to confirm the route and remaining tests were undisturbed.

---
*PR created automatically by Jules for task [2705783240412153395](https://jules.google.com/task/2705783240412153395) started by @ivanleekk*