### PR TITLE
🎨 Palette: [UX improvement] Enhance Accessibility of Icon-Only and Dialog Buttons

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -28,9 +28,9 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
-                <button
+                <button type="button" aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >
                     <X className="h-5 w-5" />
                 </button>

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -281,7 +281,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button variant="ghost" aria-label="Remove member" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}

--- a/frontend/src/pages/Portfolio/Portfolio.tsx
+++ b/frontend/src/pages/Portfolio/Portfolio.tsx
@@ -438,7 +438,7 @@ export default function Portfolio() {
                         {tab}
                     </button>
                 ))}
-                <button
+                <button type="button" aria-label="Create new portfolio"
                     onClick={() => setIsCreating(!isCreating)}
                     className={cn(
                         "px-3 py-1 text-sm font-medium transition-colors border rounded-md ml-2",

--- a/frontend/src/pages/Transactions/Transactions.tsx
+++ b/frontend/src/pages/Transactions/Transactions.tsx
@@ -605,7 +605,7 @@ export default function Transactions() {
                                         <span className={`font-semibold ${getAmountColor(item.type)}`}>
                                             {formatAmount(item.type, item.amountAccount, item.currencyAccount)}
                                         </span>
-                                        <Button
+                                        <Button aria-label="Delete transaction"
                                             variant="ghost"
                                             size="sm"
                                             className="text-base-400 hover:text-red-600 hover:bg-red-50 h-8 w-8 p-0"


### PR DESCRIPTION
**💡 What:**
Added missing `aria-label` attributes, explicit `type="button"` declarations, and keyboard focus states (`focus-visible`) to icon-only and structural buttons across the application.

**🎯 Why:**
Icon-only buttons (like the Trash icon for deleting items) and close buttons on dialogs lack discernible text for screen readers. By adding `aria-label`, users relying on assistive technologies can understand the button's purpose. Explicitly setting `type="button"` prevents accidental form submissions if the component is ever placed inside a form context. Finally, `focus-visible` utilities ensure users navigating via keyboard can clearly see which element is active.

**📸 Before/After:**
*(No visual changes for mouse users, pure accessibility enhancements for keyboard/screen reader users.)*

**♿ Accessibility:**
- `Dialog.tsx`: Added `aria-label="Close dialog"`, `type="button"`, and `focus-visible:ring-2` to the `X` icon button.
- `Households.tsx`: Added `aria-label="Remove member"` to the `Trash2` icon button.
- `Transactions.tsx`: Added `aria-label="Delete transaction"` to the `Trash2` icon button.
- `Portfolio.tsx`: Added `aria-label="Create new portfolio"` and `type="button"` to the `+ New` button.

---
*PR created automatically by Jules for task [17479343768892384272](https://jules.google.com/task/17479343768892384272) started by @ivanleekk*