### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix timing attack and info disclosure in scheduler secret

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+
+## 2024-05-27 - [Fix Timing Attack & Information Leakage in Scheduler]
+**Vulnerability:** The internal `scheduled_snapshot_job` endpoint leaked internal server errors (`str(e)`) to the client, exposing backend details. Additionally, the `verify_scheduler_secret` dependency compared authentication tokens using a standard equality operator (`!=`), leaving it vulnerable to timing attacks.
+**Learning:** Comparing cryptographic tokens or passwords directly with standard string comparisons in Python allows an attacker to deduce the token length and content character-by-character based on execution time differences. Similarly, leaking raw exceptions in APIs acts as a reconnaissance vector for attackers.
+**Prevention:** Always use `secrets.compare_digest()` for comparing security tokens or passwords to ensure constant-time verification. Always mask internal server errors with a generic HTTP detail string and log the actual trace internally. Ensure `None` checking on optional headers before digest comparison.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -55,7 +56,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 
         return {"status": "success", "processed": len(results), "details": results}
     except Exception as e:
+        print(f"Scheduled snapshot job error: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred during the scheduled snapshot job"
         )


### PR DESCRIPTION
🚨 **Severity:** CRITICAL/HIGH
💡 **Vulnerability:** 
1. **Timing Attack:** The `verify_scheduler_secret` dependency compared authentication tokens using a standard equality operator (`!=`), which is vulnerable to timing attacks.
2. **Information Disclosure:** The `scheduled_snapshot_job` endpoint leaked internal server errors (`str(e)`) to the client if an exception occurred during the execution.
🎯 **Impact:** 
1. An attacker could potentially deduce the scheduler secret token character-by-character based on execution time differences. 
2. Leaking raw exceptions in APIs acts as a reconnaissance vector, exposing backend internals and database schemas to unauthorized users.
🔧 **Fix:** 
1. Replaced the standard equality comparison with `secrets.compare_digest` to ensure constant-time token verification, explicitly handling `None` values.
2. Masked the internal exception error with a generic HTTP detail string and logged the actual trace internally to the console.
✅ **Verification:** 
- Reviewed the code changes.
- Backend linting passes via `uv run ruff check`.
- Backend tests pass without introducing new failures via `uv run pytest`.

---
*PR created automatically by Jules for task [14798477042772653375](https://jules.google.com/task/14798477042772653375) started by @ivanleekk*