### PR TITLE
🎨 Palette: Input accessibility improvements

### DIFF
--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = helperText ? `${inputId}-helper` : undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-describedby={helperTextId}
+                    aria-invalid={error ? "true" : undefined}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
**💡 What**
Added dynamic `aria-describedby` to the generic `Input` component, linking the input field to its helper text. I also added `aria-invalid` to explicitly broadcast error states.

**🎯 Why**
Previously, the helper text for the `Input` component was visually present but not programmatically associated with the `<input>` element. This meant screen reader users might not be aware of the helper text when focusing on the input field. Additionally, error states were only conveyed visually through red text borders.

**📸 Before/After**
*Before:*
```tsx
<input id="input-:r0:" type="text" />
<p>Helper text here</p>
```
*After:*
```tsx
<input id="input-:r0:" type="text" aria-describedby="input-:r0:-helper" aria-invalid="true" />
<p id="input-:r0:-helper">Helper text here</p>
```

**♿ Accessibility**
*   **WCAG 1.3.1 Info and Relationships:** Programmatically associates the helper text with the input using `aria-describedby`, ensuring screen readers announce it.
*   **WCAG 3.3.1 Error Identification:** Explicitly broadcasts error states using `aria-invalid="true"`.

---
*PR created automatically by Jules for task [16163680628316925557](https://jules.google.com/task/16163680628316925557) started by @ivanleekk*