### PR TITLE
🎨 Palette: [UX improvement] Improve Input component accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-10 - Associating Form Inputs with Helper Texts and Errors
+**Learning:** Screen readers may not automatically read helper texts or error messages adjacent to input fields. To ensure users are aware of the field's constraints or error state, the input must explicitly reference the descriptive text and signal invalid states.
+**Action:** When building or modifying form inputs, properly associate helper texts and error messages with the input element dynamically using 'aria-describedby' and broadcast error states to screen readers using 'aria-invalid'.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = helperText ? `${inputId}-helper` : undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={error ? "true" : undefined}
+                    aria-describedby={helperTextId}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
### 💡 What
Added `aria-describedby` and `aria-invalid` attributes to the reusable `Input` component.

### 🎯 Why
Screen readers may not automatically read helper texts or error messages adjacent to input fields. Explicitly referencing descriptive text ensures users are aware of the field's constraints or error state.

### 📸 Before/After
No visual changes were introduced.

### ♿ Accessibility
- `aria-describedby` associates the helper/error text with the input.
- `aria-invalid` is now properly toggled to signal invalid form constraints.

---
*PR created automatically by Jules for task [9207269465248280479](https://jules.google.com/task/9207269465248280479) started by @ivanleekk*