### PR TITLE
🛡️ Sentinel: [HIGH] Secure scheduler secret comparison and hide exception details

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-09 - [Prevent Timing Attacks on Scheduler Secret and Hide Exception Details]
+**Vulnerability:** The internal API endpoint for running daily snapshots used a basic string equality check (`==` / `!=`) for the scheduler secret, which was vulnerable to timing attacks. Also, an overly broad exception handler returned `str(e)`, leaking internal implementation details (such as stack traces or internal errors) directly to the client.
+**Learning:** Naive string comparison of secrets in Python should be avoided; `secrets.compare_digest` must be used instead. Also, handling generic exceptions shouldn't expose internal variables in public-facing errors.
+**Prevention:** Use `secrets.compare_digest(a, b)` for constant-time comparison when verifying tokens, passwords, or secrets. Check for `None` before applying `compare_digest`. Ensure `detail` fields in HTTP exceptions return generalized user-friendly error messages rather than raw internal error outputs.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +55,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An error occurred while processing the daily snapshot job."
         )


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `/tasks/daily-snapshot` endpoint in `internal.py` was vulnerable to timing attacks due to naive string comparison of the `x_scheduler_secret` header. Furthermore, an overbroad exception block returned `str(e)` in the HTTPException, which could leak internal implementations, stack traces, or other sensitive details to clients.
🎯 Impact: An attacker could potentially figure out the scheduler secret via a timing attack and maliciously trigger scheduled jobs. Furthermore, they could cause deliberate errors to harvest server internals and debug traces through the exposed exception details.
🔧 Fix: Used `secrets.compare_digest` from the `secrets` standard library to ensure constant-time string comparison. Replaced the error details in the generic Exception block with a safe, generalized message. 
✅ Verification: Ran `pytest` ensuring no tests in the internal router broke, and validated the lint format using `ruff`. Verified behavior that no unhandled exceptions or internal stack traces are returned in the response payload.

---
*PR created automatically by Jules for task [3812711362838968525](https://jules.google.com/task/3812711362838968525) started by @ivanleekk*