### PR TITLE
🎨 Palette: Enhance Input Accessibility with ARIA attributes

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-30 - Form Input Accessibility
+**Learning:** Generic input components often lack proper ARIA associations for dynamically rendered helper/error texts, leaving screen reader users unaware of critical context or validation failures.
+**Action:** Always dynamically generate an `id` for helper text elements and bind them to the `<input>` using `aria-describedby`, while simultaneously broadcasting validation states with `aria-invalid`.

--- a/frontend/src/components/ui/Input.tsx
+++ b/frontend/src/components/ui/Input.tsx
@@ -11,6 +11,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
     ({ className, type, error, label, helperText, disabled, id, ...props }, ref) => {
         const generatedId = React.useId()
         const inputId = id || generatedId
+        const helperTextId = helperText ? `${inputId}-description` : undefined
 
         return (
             <div className="flex w-full flex-col gap-1.5">
@@ -29,6 +30,8 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                     type={type}
                     id={inputId}
                     disabled={disabled}
+                    aria-invalid={error ? "true" : undefined}
+                    aria-describedby={helperTextId}
                     className={cn(
                         "flex h-10 w-full rounded-md border border-base-300 bg-white px-3 py-2 text-sm text-base-900 placeholder:text-base-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:bg-base-100 disabled:text-base-500 dark:border-base-800 dark:bg-base-950 dark:text-base-50 dark:placeholder:text-base-600 dark:disabled:bg-base-900 dark:disabled:text-base-600",
                         {
@@ -41,6 +44,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
                 />
                 {helperText && (
                     <p
+                        id={helperTextId}
                         className={cn("text-sm text-base-500 dark:text-base-400", {
                             "text-red-500 dark:text-red-400": error && !disabled,
                             "text-base-400 dark:text-base-600": disabled,


### PR DESCRIPTION
💡 **What**: Dynamically assigned a unique `id` to the helper text and associated it to the `<input>` element via `aria-describedby` inside `frontend/src/components/ui/Input.tsx`. Additionally, it propagates error states dynamically using `aria-invalid`.

🎯 **Why**: Generic input components natively lack associations for helper texts and error states. Without this ARIA mapping, screen reader users miss crucial validation context, leading to frustrating form-filling experiences.

📸 **Before/After**: Visually identical. This is purely a semantic HTML/ARIA structural change. (Screenshots and Videos validated).

♿ **Accessibility**: Significant improvement. Screen readers will now automatically narrate the helper text (including errors) as soon as the input field gains focus, empowering fully accessible error resolution.

---
*PR created automatically by Jules for task [10422163153011538287](https://jules.google.com/task/10422163153011538287) started by @ivanleekk*