### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix timing attack vulnerability and information disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-06-11 - [Timing Attack in Scheduler Secret Verification]
+**Vulnerability:** A simple string comparison (`!=`) was used to compare the scheduler secret header with the expected secret, making the endpoint vulnerable to timing attacks. Additionally, exceptions were leaking internal details (`detail=str(e)`).
+**Learning:** Even internal or scheduled endpoints require secure comparison operations (`secrets.compare_digest`) for authorization headers, and error handling must always return generic responses. Optional dependencies like `Header(None)` must be explicitly checked for `None` before being passed into secure comparison functions to avoid `TypeError`.
+**Prevention:** Always use constant-time comparison functions for secrets/tokens and avoid exposing stringified exception details (`str(e)`) in API responses.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if not x_scheduler_secret or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Internal server error"
         )


### PR DESCRIPTION
🚨 **Severity:** CRITICAL / HIGH

💡 **Vulnerability:** 
1. The `/internal/tasks/daily-snapshot` endpoint verified the `x-scheduler-secret` header using a simple string equality check (`!=`), which is vulnerable to timing attacks.
2. The endpoint exposed internal error details to the client by setting `detail=str(e)` in its `HTTPException`.

🎯 **Impact:** 
1. An attacker could potentially guess the scheduler secret character by character by measuring the response time, bypassing the authorization.
2. If the snapshot engine fails, the error message could leak internal database schema, file structure, or system state.

🔧 **Fix:** 
- Used `secrets.compare_digest` for a constant-time comparison of the scheduler secret, protecting against timing attacks. Added a safe fallback check for when the header is `None`.
- Replaced the `detail=str(e)` response with a generic `"Internal server error"` string to prevent information leakage.

✅ **Verification:** 
- Verified `ruff check` passes.
- Verified test suite passes locally. Code review approved the changes.

---
*PR created automatically by Jules for task [9946660360979057858](https://jules.google.com/task/9946660360979057858) started by @ivanleekk*