### PR TITLE
🎨 Palette: [UX improvement] Dialog close button accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What:** Improved the accessibility and usability of the generic `Dialog` component's close button.
🎯 **Why:** The close button (an `X` icon from `lucide-react`) lacked an `aria-label`, making it difficult for screen readers to identify its purpose. It also lacked `type="button"`, which could cause accidental form submissions if the Dialog is used within a form. Finally, it didn't have distinct focus styles for keyboard navigation, making it hard to see when focused.
📸 **Before/After:** No visual changes for mouse users. Keyboard users will now see a clear blue focus ring (`ring-primary-500`) when tabbing to the close button.
♿ **Accessibility:** Added `aria-label="Close dialog"`, explicit `type="button"`, and keyboard focus indicator via `focus-visible:ring-2`.

---
*PR created automatically by Jules for task [7343943970777245618](https://jules.google.com/task/7343943970777245618) started by @ivanleekk*