### PR TITLE
🎨 Palette: [UX improvement] Accessible Dialog Close Button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-14 - Accessible Close Button in Dialog
+**Learning:** Found an icon-only button inside the Dialog component that was missing an ARIA label, explicit button type, and focus styles, impacting keyboard navigation and screen reader accessibility.
+**Action:** Added `aria-label="Close dialog"`, `type="button"`, and standard focus styles (`focus-visible:ring-2 focus-visible:ring-primary-500`) to the Dialog close button. We should always check generic UI components for accessible icon-only buttons as they are reused widely.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
**💡 What:** Added essential accessibility attributes (`aria-label`, explicit `type="button"`, and keyboard focus styling) to the icon-only close button within the reusable `Dialog` component.

**🎯 Why:** The `Dialog` close button was purely an icon without an accessible label, making it difficult for screen reader users to identify its purpose. It also lacked a `type="button"` attribute (risking accidental form submissions if nested) and had poor keyboard focus visibility, reducing usability for power users.

**📸 Before/After:** N/A (Functional change to ARIA, type, and focus styles, visual appearance on blur remains identical)

**♿ Accessibility:**
- Added `aria-label="Close dialog"` so screen readers properly announce the button's action.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to ensure keyboard navigation displays a clear, highly visible focus ring.
- Fixed button type implicitly to `type="button"` to prevent it acting as a submit button when inside forms.
- Added a learning to `.jules/palette.md` to consistently check reusable icon buttons for accessibility.

---
*PR created automatically by Jules for task [7237485475492320528](https://jules.google.com/task/7237485475492320528) started by @ivanleekk*