### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and info disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-27 - [Fix timing attack and info disclosure in internal router]
+**Vulnerability:** The internal `/tasks/daily-snapshot` endpoint checked `x_scheduler_secret != expected_secret` causing a timing vulnerability. Furthermore, it returned `detail=str(e)` on unhandled exceptions and specifically noted `"SCHEDULER_SECRET not set"` in error details, leaking sensitive internal server paths/state to the client.
+**Learning:** Using `==` or `!=` to verify secret tokens allows attackers to measure the time taken to reject an invalid secret and deduce the valid string byte by byte. Also, FastAPI `HTTPException` responses must use sanitized, generic messages instead of raw exceptions `str(e)`.
+**Prevention:** Always use `secrets.compare_digest()` for string comparisons of security secrets (with prior null-checking if optional via `Header(None)`), and use generic messages like `"An internal server error occurred"` for generic HTTP 500 exceptions.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -16,9 +17,9 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
         # If no secret is configured, deny all requests for safety
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail="Server configuration error: SCHEDULER_SECRET not set"
+            detail="Server configuration error"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:**
1. The `/tasks/daily-snapshot` internal endpoint in `backend/src/routers/internal.py` was vulnerable to timing attacks when verifying the `x_scheduler_secret` header.
2. The endpoint leaked sensitive server configuration details (the name of the expected environment variable `SCHEDULER_SECRET`) and raw exception traces (`str(e)`) via HTTP 500 responses.

🎯 **Impact:** An attacker could deduce the `SCHEDULER_SECRET` character by character by measuring request latency, bypassing authorization on internal scheduled tasks. Furthermore, unhandled internal exceptions could expose stack traces, database states, or internal configuration to untrusted clients.

🔧 **Fix:**
- Replaced standard string inequality (`!=`) with the constant-time `secrets.compare_digest()` for the secret token comparison (with a necessary `is None` safeguard to prevent `TypeError`).
- Replaced raw exception string responses with a generic "An internal server error occurred" message.
- Replaced the specific "SCHEDULER_SECRET not set" detail with a generic "Server configuration error".

✅ **Verification:** Verified by running `pytest` test suite and `ruff` checks ensuring no regressions were introduced to the module.

---
*PR created automatically by Jules for task [8301979112106949767](https://jules.google.com/task/8301979112106949767) started by @ivanleekk*