### PR TITLE
🎨 Palette: Add accessibility to Dialog close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-06-15 - Dialog Close Button Accessibility
+**Learning:** Icon-only close buttons in modal dialogs (like `Dialog.tsx`) are often overlooked for accessibility. They need explicit `type="button"`, an `aria-label`, and clear `focus-visible` styling since they are typically the first element to receive focus when a dialog opens.
+**Action:** Always add `type="button"`, `aria-label`, and `focus-visible` states to floating/icon-only action buttons to ensure keyboard and screen reader accessibility.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What:**
Added `type="button"`, `aria-label="Close dialog"`, and `focus-visible` styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500`) to the icon-only close button within the `Dialog` component.

🎯 **Why:**
The close button in the `Dialog` modal lacked an accessible name, making it difficult for screen reader users to understand its function. Furthermore, it did not have clear keyboard focus indicators, which is a critical UX requirement for modals where the close button is often the first element to receive focus.

📸 **Before/After:**
*Before:* The close button was a plain `<button>` containing only an SVG `<X />` icon, lacking explicit focus styling for keyboard navigation.
*After:* The close button now has an explicit `aria-label`, explicitly defines `type="button"`, and highlights with a primary colored focus ring when navigated via the `Tab` key.

♿ **Accessibility:**
- Resolved a missing semantic label issue for screen readers.
- Greatly improved keyboard navigation within all dialogs across the application by providing a visible focus indicator.

---
*PR created automatically by Jules for task [16921113290158457367](https://jules.google.com/task/16921113290158457367) started by @ivanleekk*