### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack in secret verification

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-15 - [Prevent Timing Attacks in Secret Verification]
+**Vulnerability:** The scheduler secret was being compared using the `!=` operator, which is vulnerable to timing attacks as string comparison short-circuits. Furthermore, the generic catch-all exception leak details to the caller by passing `str(e)` in the `detail` parameter.
+**Learning:** Python's standard equality operators check character by character and can return early. In internal.py, exceptions were leaking information.
+**Prevention:** Always use `secrets.compare_digest` for security tokens, passwords, and sensitive keys comparison. Ensure that optional dependency variables handle `None` values prior to comparing. Use generic exception details to protect server internals.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -57,5 +58,5 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
     except Exception as e:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred during the scheduled snapshot job."
         )


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: 
1. The scheduler secret was verified using a direct string comparison (`!=`), exposing the endpoint to potential timing attacks that could reveal the correct secret character-by-character.
2. The catch-all `Exception` block passed the raw exception string `str(e)` directly back to the client in the response body, which could leak stack traces or internal server details on error.

🎯 **Impact**: An attacker could potentially brute force the `SCHEDULER_SECRET` via a timing attack and subsequently trigger daily snapshots unauthorized. They could also intentionally cause internal errors to map out server infrastructure.

🔧 **Fix**: 
1. Replaced the `!=` check with `secrets.compare_digest` to ensure constant-time verification.
2. Handled the `None` case correctly before applying digest comparison.
3. Updated the `Exception` block to return a generic "An internal error occurred" message to mask internal faults from clients.

✅ **Verification**: Code review confirms the fixes are applied accurately, and tests pass as expected. The new memory has been recorded to prevent timing attacks in the future.

---
*PR created automatically by Jules for task [8610323968664646044](https://jules.google.com/task/8610323968664646044) started by @ivanleekk*