### PR TITLE
🎨 Palette: [UX improvement] Add ARIA label and focus styles to Dialog close button

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
### 💡 What
Added `type="button"`, `aria-label="Close dialog"`, and `focus-visible` styling classes to the icon-only Close (`X`) button in `frontend/src/components/ui/Dialog.tsx`.

### 🎯 Why
- **Safety:** Icon-only buttons without an explicit `type="button"` attribute default to `type="submit"` within a form, which can accidentally submit data if the Dialog is ever nested inside one.
- **Accessibility:** Screen readers cannot interpret an `<X />` icon without text. Adding an `aria-label` ensures screen reader users understand what the button does.
- **Usability:** Users navigating via keyboard need to clearly see which element has focus. Adding `focus-visible` styles ensures a clear focus ring appears.

### 📸 Before/After
*(See Playwright verification screenshots and video for the visible focus ring)*
- **Before:** `<button onClick={onClose} className="..."><X /></button>`
- **After:** `<button type="button" aria-label="Close dialog" onClick={onClose} className="... focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"><X /></button>`

### ♿ Accessibility
- Improved screen reader support with `aria-label`.
- Improved keyboard navigation support with `focus-visible` styling.

---
*PR created automatically by Jules for task [17323482936098484424](https://jules.google.com/task/17323482936098484424) started by @ivanleekk*