### PR TITLE
🎨 Palette: Improve Dialog close button accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-17 - Added Accessibility to Dialog Close Button
+**Learning:** Icon-only close buttons in modal dialogs frequently lack ARIA labels, explicit button types (preventing accidental form submission context issues), and keyboard focus indicators, rendering them invisible or confusing to screen readers and keyboard users.
+**Action:** Always verify that generic or icon-only `<button>` elements have `type="button"`, a descriptive `aria-label`, and `focus-visible` classes (like `focus-visible:ring-2` with an appropriate ring color) in the underlying UI component libraries.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,10 @@
+1. **Analyze UI for UX improvements**: Looking through `frontend/src/components/ui/Dialog.tsx`, I noticed the close button is an icon-only button without an `aria-label`. It's a standard `<button>` that doesn't explicitly have `type="button"`, and could use some focus styling for better keyboard accessibility (`focus-visible:ring-2 focus-visible:ring-primary-500 focus-visible:outline-none`).
+2. **Make the Dialog close button accessible**: Update the `frontend/src/components/ui/Dialog.tsx` file to include `aria-label="Close dialog"`, `type="button"`, and add focus classes.
+3. **Check other UI components**:
+   - `frontend/src/components/ui/TimeframeSelector.tsx` needs `type="button"` and focus classes on the `<button>`.
+   - `frontend/src/components/sidebar.tsx` has a logout button that is inside a `<Form>` so `type="submit"` is correct, but let's make sure it's fully accessible.
+   - `frontend/src/components/sidebarButton.tsx` needs `type="button"` for the onClick branch.
+4. **Select the single best UX improvement**: Enhancing the `Dialog.tsx` close button with an `aria-label`, explicit `type="button"`, and `focus-visible` outline is a classic, high-impact Palette UX improvement. It improves accessibility for screen readers and keyboard users on all modals. Let's do this one.
+5. **Verify changes**: Run `pnpm test` and `pnpm lint` in the `frontend` directory.
+6. **Complete pre-commit steps**: "Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done."
+7. **Submit PR**: Submit the PR with the required Palette format.


### PR DESCRIPTION
💡 **What:** Added `type="button"`, `aria-label="Close dialog"`, and `focus-visible` styling to the icon-only close button within the core `Dialog` UI component.

🎯 **Why:** Icon-only buttons without ARIA labels are opaque to screen readers. Without explicit `type="button"`, they can trigger accidental form submissions if nested within a `<form>` or `<Form>`. Without `focus-visible` classes, keyboard users (like those navigating via `Tab`) cannot easily see when the close button is focused, making it difficult to dismiss modals without a mouse.

📸 **Before/After:** The visual change applies a focus ring around the "X" button when it receives keyboard focus, clearly indicating its state to keyboard-driven users.

♿ **Accessibility:**
- Added `aria-label="Close dialog"` so screen readers properly announce the button's purpose.
- Added `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500` to provide a clear, high-contrast visual focus indicator.
- Added `type="button"` to ensure it behaves predictably as a standalone button without side effects.

---
*PR created automatically by Jules for task [15942753984752699972](https://jules.google.com/task/15942753984752699972) started by @ivanleekk*