### PR TITLE
🎨 Palette: [UX improvement] Add accessibility to Dialog close button

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What:** Added accessibility improvements to the generic Dialog component's close button.\n🎯 **Why:** To ensure modal close buttons are screen-reader accessible (`aria-label`), prevent unintended form submissions (`type="button"`), and clearly indicate focus for keyboard users (`focus-visible`).\n📸 **Before/After:** The close button now displays a prominent primary color focus ring when navigated via keyboard.\n♿ **Accessibility:** Added ARIA label, explicit button type, and visible focus indicators.

---
*PR created automatically by Jules for task [13863219480750409516](https://jules.google.com/task/13863219480750409516) started by @ivanleekk*