### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and info disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Information Disclosure & Timing Attack in Internal Router
+**Vulnerability:** The `/internal/tasks/daily-snapshot` endpoint exposed raw exception details to the client via `str(e)` in the error handler. Additionally, the `verify_scheduler_secret` dependency used standard string comparison `!=` for verifying the authentication secret.
+**Learning:** Exposing raw `str(e)` errors from database queries or internal application logic leaks stack traces or internal structure that an attacker can use for reconnaissance. Standard string comparisons short-circuit when they find a mismatch, allowing an attacker to determine the secret character by character via timing attacks.
+**Prevention:** Always use generic HTTP error messages for internal exceptions (and log the actual error internally). Always use `secrets.compare_digest` when comparing sensitive tokens or secrets, taking care to handle potential `None` values beforehand to avoid TypeErrors.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +55,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred during the snapshot job."
         )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** 
1. **Timing Attack:** The `/internal/tasks/daily-snapshot` endpoint used standard `!=` string comparison to verify the `x-scheduler-secret` header. This allows attackers to perform timing attacks to guess the secret.
2. **Information Disclosure:** The error handler for `scheduled_snapshot_job` returned the raw exception string `str(e)` to the client upon failure, potentially exposing sensitive database or stack trace details.

🎯 **Impact:** Attackers could deduce the scheduler secret or gain internal knowledge of the application's backend architecture for further reconnaissance.
🔧 **Fix:** 
- Modified `backend/src/routers/internal.py` to use `secrets.compare_digest` for constant-time secret comparison. Included a `None` check to safely handle missing secrets.
- Replaced `detail=str(e)` with a generic string to prevent information leakage.
✅ **Verification:** Verified by running the existing test suite and `uv run ruff check`. Code review confirmed correct and safe handling of the logic.

---
*PR created automatically by Jules for task [15090188005235040073](https://jules.google.com/task/15090188005235040073) started by @ivanleekk*