### PR TITLE
🎨 Palette: Add ARIA label and focus styles to Dialog close button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-12 - Dialog component missing generic a11y parameters
+**Learning:** Found that the generic `Dialog` component's close button lacked an `aria-label`, a `type="button"` attribute (risking form submissions if used within one), and `focus-visible` styling, making it invisible to keyboard navigation. This pattern often occurs with generic, icon-only buttons built from scratch.
+**Action:** When implementing buttons in the frontend, particularly generic or icon-only buttons, always explicitly set `type="button"` to prevent accidental form submissions, include `aria-label` for screen readers, and apply `focus-visible:ring-2` (or similar) Tailwind classes to ensure proper keyboard focus visibility.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -29,8 +29,10 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
+                    aria-label="Close dialog"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
💡 **What:** Added `type="button"`, `aria-label="Close dialog"`, and `focus-visible` styling (`focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500`) to the icon-only close button within the `Dialog` component (`frontend/src/components/ui/Dialog.tsx`).

🎯 **Why:** Icon-only buttons without ARIA labels are inaccessible to screen reader users, who will just hear "button" without knowing its function. In addition, missing `focus-visible` styling means keyboard users cannot see when the button has focus. Finally, omitting `type="button"` on a `<button>` tag defaults it to a submit button, which can cause unexpected form submissions if the dialog is placed within a `<form>` or `<Form>` element in React Router. 

📸 **Before/After:**
*(Visual changes verified via screenshot - the button now has a visible blue focus ring when navigated to via the `Tab` key).*

♿ **Accessibility:** 
- The button is now fully accessible to screen readers via its `aria-label`.
- It fully supports keyboard navigation visibility via explicit focus rings.
- Accidental form submissions are prevented.

---
*PR created automatically by Jules for task [16325451012163405807](https://jules.google.com/task/16325451012163405807) started by @ivanleekk*