### PR TITLE
🎨 Palette: Add accessibility attributes to Dialog component

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -22,15 +22,20 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
+                aria-hidden="true"
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
**💡 What:** 
Added core accessibility attributes to the custom `Dialog` component, including roles, modal indicators, hidden backdrops, and proper button properties for the close action.

**🎯 Why:** 
The previous implementation lacked standard ARIA roles and labels, meaning screen readers would struggle to interpret the boundaries and interactivity of the modal. Keyboard users also lacked a clear visual indicator when focusing the close button.

**📸 Before/After:** 
_No major visual change, except when focusing the close button via keyboard (adds a focus ring)._

**♿ Accessibility:** 
- The modal wrapper now correctly announces as a `dialog` trap (`role="dialog"`, `aria-modal="true"`).
- The visual backdrop is now hidden from assistive technologies (`aria-hidden="true"`).
- The close button explicitly announces its purpose (`aria-label="Close dialog"`), prevents accidental form submissions (`type="button"`), and has a clear focus indicator (`focus-visible:ring-2 focus-visible:ring-primary-500`).

---
*PR created automatically by Jules for task [10525173828006458530](https://jules.google.com/task/10525173828006458530) started by @ivanleekk*