### PR TITLE
🎨 Palette: [a11y] Enhance Dialog accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -22,17 +22,22 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
+                aria-hidden="true"
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
-                    <X className="h-5 w-5" />
+                    <X className="h-5 w-5" aria-hidden="true" />
                 </button>
                 {children}
             </div>


### PR DESCRIPTION
💡 **What**: Improved the accessibility of the reusable `Dialog` component by adding appropriate ARIA attributes and enhancing the focus state of the close button.

🎯 **Why**: 
- Dialog elements need explicit ARIA roles so screen readers can correctly identify and announce them as modal dialogs.
- The backdrop must have `aria-hidden="true"` to ensure screen readers focus only on the modal content.
- The close button is icon-only, meaning it was completely invisible to screen readers without an `aria-label`. 
- Improved keyboard focus via `focus-visible` to assist sighted users navigating via the Tab key.

♿ **Accessibility**:
- Added `role="dialog"` and `aria-modal="true"`.
- Added `aria-hidden="true"` to the backdrop and the inner `<X />` SVG.
- Added `type="button"`, `aria-label="Close dialog"`, and explicitly set `focus-visible:ring-2 focus-visible:ring-primary-500 rounded-full` on the close `<button>`.

---
*PR created automatically by Jules for task [18417591769829268897](https://jules.google.com/task/18417591769829268897) started by @ivanleekk*