### PR TITLE
🎨 Palette: [a11y] Improve Dialog accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-06-22 - [Dialog Accessibility Enhancements]
+**Learning:** Found that custom `Dialog` components were missing critical screen reader attributes and focus states for icon buttons.
+**Action:** Added `role="dialog"`, `aria-modal="true"`, `aria-hidden="true"` on the backdrop, and proper `type="button"`, `aria-label`, and `focus-visible` styles to the close button to ensure proper accessibility in standard modal patterns.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -22,15 +22,20 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
+                aria-hidden="true"
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    type="button"
                     onClick={onClose}
-                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
+                    className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
### 💡 What
Added essential WAI-ARIA accessibility attributes to the shared `Dialog` component.

### 🎯 Why
To ensure the `Dialog` component properly announces its purpose and state to assistive technologies like screen readers, and to improve keyboard navigation by providing clear focus states on the close button.

### 📸 Before/After
*(Visual changes are minimal, primarily focus state improvements when navigating via keyboard)*

### ♿ Accessibility
- **Screen Readers**: Added `role="dialog"` and `aria-modal="true"` to correctly identify the modal.
- **Screen Readers**: Added `aria-hidden="true"` to the backdrop so screen readers ignore this visual-only element.
- **Screen Readers**: Added `aria-label="Close dialog"` to the icon-only 'X' close button.
- **Keyboard Navigation**: Added `focus-visible:ring-2` to the close button for proper focus ring visualization.
- **Forms**: Added `type="button"` to the close button to prevent accidental form submissions if the dialog is nested inside a form.

---
*PR created automatically by Jules for task [10658595200864505936](https://jules.google.com/task/10658595200864505936) started by @ivanleekk*