### PR TITLE
⚡ Bolt: [performance improvement] O(N) Time-Series Chart Aggregation

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -83,32 +83,45 @@ export default function Dashboard() {
 
     // Aggregate historical data for the chart using real snapshots and carrying forward cash
     const chartData = useMemo(() => {
+        // ⚡ BOLT OPTIMIZATION: O(N) Time-Series Aggregation
+        // Replaced O(N*M) nested filters/finds inside the render loop with O(N+M) single-pass Hash Maps.
+        // Pre-calculating daily updates avoids recalculating arrays for every single date in history.
+        // Expected impact: Eliminates UI freezing on large datasets, reducing aggregation time from O(D*A*H) to O(D+A*H).
+
         const allDatesSet = new Set<string>();
-        snapshots.forEach(s => allDatesSet.add(s.date));
-        Object.values(balances).forEach(history => {
-            history.forEach(b => allDatesSet.add(b.date));
+        const portfolioByDate = new Map<string, number>();
+        snapshots.forEach(s => {
+            allDatesSet.add(s.date);
+            portfolioByDate.set(s.date, (portfolioByDate.get(s.date) || 0) + Number(s.current_value_home_currency));
         });
 
-        const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+        const balanceUpdatesByDate = new Map<string, Array<{accId: string, balance: number}>>();
+        Object.entries(balances).forEach(([accId, history]) => {
+            history.forEach(b => {
+                allDatesSet.add(b.date);
+                const arr = balanceUpdatesByDate.get(b.date) || [];
+                arr.push({ accId, balance: Number(b.balance_home_currency ?? b.balance) });
+                balanceUpdatesByDate.set(b.date, arr);
+            });
+        });
+
+        const sortedDates = Array.from(allDatesSet).sort((a, b) => a > b ? 1 : a < b ? -1 : 0);
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
+        let currentTotalCash = 0;
         
         const rawData = sortedDates.map(date => {
-            // Update latest balances for any account that has a record on THIS date
-            Object.entries(balances).forEach(([accId, history]) => {
-                const balOnDate = history.find(b => b.date === date);
-                if (balOnDate) {
-                    accountLatestBalances.set(accId, Number(balOnDate.balance_home_currency ?? balOnDate.balance));
-                }
-            });
+            const updates = balanceUpdatesByDate.get(date);
+            if (updates) {
+                updates.forEach(u => {
+                    const oldBal = accountLatestBalances.get(u.accId) || 0;
+                    currentTotalCash += (u.balance - oldBal);
+                    accountLatestBalances.set(u.accId, u.balance);
+                });
+            }
 
-            const currentTotalCash = Array.from(accountLatestBalances.values()).reduce((sum, val) => sum + val, 0);
-            
-            // Get portfolio snapshots for this date
-            const currentTotalPortfolio = snapshots
-                .filter(s => s.date === date)
-                .reduce((sum, s) => sum + Number(s.current_value_home_currency), 0);
+            const currentTotalPortfolio = portfolioByDate.get(date) || 0;
 
             return {
                 date,


### PR DESCRIPTION
💡 What: Replaced nested `find`/`filter`/`reduce` inside the dashboard chart's multi-dimensional time-series mapping with pre-aggregated `Map`s for an O(N) single-pass algorithm.
🎯 Why: The original nested approach ran an array search for every account on every date, creating an O(N*M) bottleneck that would freeze the UI with large datasets (lots of accounts over many years).
📊 Impact: Transforms time complexity from quadratic to linear mapping scale. Aggregation time expected to drop from O(D*A*H) to O(D+A*H), completely eliminating UI stutter when rendering the chart for portfolios with deep history.
🔬 Measurement: Verified functionality by passing all frontend unit tests (`pnpm test`) and linters without regressions. Can be tested visually by viewing the dashboard with multiple accounts over a "Max" timeframe to verify smooth render response.

---
*PR created automatically by Jules for task [89516673322050793](https://jules.google.com/task/89516673322050793) started by @ivanleekk*