### PR TITLE
🎨 Palette: [UX improvement] Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -31,7 +31,7 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
                 <button
                     onClick={onClose}
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
-                >
+                 aria-label="Close dialog">
                     <X className="h-5 w-5" />
                 </button>
                 {children}

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -281,7 +281,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto" aria-label="Remove member">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}


### PR DESCRIPTION
💡 **What:** Added `aria-label` attributes to the icon-only "Close" button in the `Dialog` component and the "Remove member" button in the `Households` component.
🎯 **Why:** To improve accessibility for screen reader users by providing clear context for these icon-only interactive elements.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now announce "Close dialog" and "Remove member" respectively when focusing on these buttons, improving the experience for visually impaired users.

---
*PR created automatically by Jules for task [7692256098778013837](https://jules.google.com/task/7692256098778013837) started by @ivanleekk*