### PR TITLE
🎨 Palette: Improve Dialog accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -22,17 +22,21 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
+                aria-hidden="true"
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
                     onClick={onClose}
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close dialog"
                 >
-                    <X className="h-5 w-5" />
+                    <X className="h-5 w-5" aria-hidden="true" />
                 </button>
                 {children}
             </div>


### PR DESCRIPTION
💡 What: Added standard WAI-ARIA roles and attributes to the shared `Dialog` component.
🎯 Why: To ensure screen readers properly interpret the modal container as a dialog, prevent the background overlay and graphical `X` icon from creating noise, and provide an explicit text label for the icon-only close button.
📸 Before/After: The visual appearance remains completely unchanged.
♿ Accessibility:
- Added `role="dialog"` and `aria-modal="true"` to the inner modal container.
- Added `aria-hidden="true"` to the decorative backdrop overlay.
- Added `aria-label="Close dialog"` to the close `<button>`.
- Added `aria-hidden="true"` to the purely decorative `<X>` SVG icon.

---
*PR created automatically by Jules for task [4740460228249345061](https://jules.google.com/task/4740460228249345061) started by @ivanleekk*