### PR TITLE
⚡ Bolt: [performance improvement] Optimize time-series chart data aggregation

### DIFF
--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -89,26 +89,44 @@ export default function Dashboard() {
             history.forEach(b => allDatesSet.add(b.date));
         });
 
-        const sortedDates = Array.from(allDatesSet).sort((a, b) => a.localeCompare(b));
+        // OPTIMIZATION: Compare strings using relational operators instead of localeCompare for performance
+        const sortedDates = Array.from(allDatesSet).sort((a, b) => a < b ? -1 : (a > b ? 1 : 0));
         
         // Track the latest balance for each account to "carry forward"
         const accountLatestBalances = new Map<string, number>();
         
+        // OPTIMIZATION: Pre-compute maps for O(1) lookups during the date iteration
+        // Avoids O(N) array scans inside the loop which blocked the main thread
+        const balancesByDate = new Map<string, Array<{accId: string, val: number}>>();
+        Object.entries(balances).forEach(([accId, history]) => {
+            history.forEach(b => {
+                const dateUpdates = balancesByDate.get(b.date) || [];
+                dateUpdates.push({ accId, val: Number(b.balance_home_currency ?? b.balance) });
+                balancesByDate.set(b.date, dateUpdates);
+            });
+        });
+
+        const portfolioByDate = new Map<string, number>();
+        snapshots.forEach(s => {
+            const current = portfolioByDate.get(s.date) || 0;
+            portfolioByDate.set(s.date, current + Number(s.current_value_home_currency));
+        });
+
+        let currentTotalCash = 0;
+
         const rawData = sortedDates.map(date => {
             // Update latest balances for any account that has a record on THIS date
-            Object.entries(balances).forEach(([accId, history]) => {
-                const balOnDate = history.find(b => b.date === date);
-                if (balOnDate) {
-                    accountLatestBalances.set(accId, Number(balOnDate.balance_home_currency ?? balOnDate.balance));
-                }
-            });
+            const updates = balancesByDate.get(date);
+            if (updates) {
+                updates.forEach(u => {
+                    const oldVal = accountLatestBalances.get(u.accId) || 0;
+                    currentTotalCash += (u.val - oldVal);
+                    accountLatestBalances.set(u.accId, u.val);
+                });
+            }
 
-            const currentTotalCash = Array.from(accountLatestBalances.values()).reduce((sum, val) => sum + val, 0);
-            
             // Get portfolio snapshots for this date
-            const currentTotalPortfolio = snapshots
-                .filter(s => s.date === date)
-                .reduce((sum, s) => sum + Number(s.current_value_home_currency), 0);
+            const currentTotalPortfolio = portfolioByDate.get(date) || 0;
 
             return {
                 date,


### PR DESCRIPTION
💡 **What**: Refactored the `useMemo` block in `Dashboard.tsx` that aggregates historical data for the area chart. Removed recursive `Array.prototype.find()`, `filter()`, and `reduce()` calls that were executing inside an outer `.map()` loop. Replaced them with pre-computed Hash Maps (`balancesByDate`, `portfolioByDate`) and a running tally for `currentTotalCash`. Also switched date string sorting from `localeCompare` to standard relational operators.

🎯 **Why**: In a dashboard with a large historical dataset, computing running balances and aggregating data dynamically in a render loop via nested filters/sorts results in a catastrophic main-thread bottleneck (e.g., $O(D \times A \times H)$ time complexity). This caused the UI to freeze during chart renders. The new O(N) single-pass approach avoids doing heavy array operations recursively on every data point.

📊 **Impact**: Reduces time complexity from $O(D \times (H + S + A))$ to $O(H + S + D \log D)$. Should completely eliminate main-thread blocking during chart renders, even for users with thousands of historical records and multiple accounts.

🔬 **Measurement**: Verify that the application continues to correctly render the Dashboard Area Chart (Net Worth, Portfolio, Cash) and that the UI remains highly responsive when manipulating the date range or returning to the page, particularly with a large seeded dataset. All unit tests (`Dashboard.test.tsx`) pass.

---
*PR created automatically by Jules for task [9731276719104709787](https://jules.google.com/task/9731276719104709787) started by @ivanleekk*