### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix info disclosure and timing attack vulnerabilities in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2025-02-28 - Information Disclosure and Timing Attack in Scheduled Snapshot Job
+**Vulnerability:** The internal daily-snapshot cronjob endpoint (`/internal/tasks/daily-snapshot`) had two critical vulnerabilities: a timing attack vulnerability on the secret authentication (`x_scheduler_secret != expected_secret`) and information disclosure leaking potentially sensitive traceback messages directly to external clients via `str(e)`.
+**Learning:** Using `!=` on headers exposes string comparison times which could theoretically allow attackers to guess the token char by char. Also, returning unhandled exception strings (`str(e)`) via HTTP 500 can reveal database states or internal service structures.
+**Prevention:** Always use `secrets.compare_digest` for secret validation, and catch generic exceptions to log them with `logging.getLogger(__name__).error(..., exc_info=True)` while returning a safe, generic HTTP 500 error string to the client.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
-
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+import secrets
+import logging
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +22,8 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    # SECURITY: Use secrets.compare_digest to prevent timing attacks
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +59,10 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        # SECURITY: Log error internally to prevent information disclosure
+        logger.error("Failed to run scheduled snapshot job", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal error occurred during the snapshot job"
         )


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The internal daily-snapshot cronjob endpoint (`/internal/tasks/daily-snapshot`) had two critical vulnerabilities:
1. **Timing Attack:** The `verify_scheduler_secret` dependency used standard string comparison (`!=`) for validating the scheduler secret, allowing an attacker to theoretically guess the token character by character based on response times.
2. **Information Disclosure:** The `scheduled_snapshot_job` leaked raw Python exception stack traces and strings (`str(e)`) directly to the client in HTTP 500 error responses, potentially exposing database states, column names, or other internal application context.

🎯 **Impact:** Attackers could bypass authentication by guessing the scheduler secret, allowing them to repeatedly trigger massive database snapshot runs (DoS attack vector), and could mine the server for internal schema or backend state context via forced generic 500 exceptions.

🔧 **Fix:** 
1. Replaced `x_scheduler_secret != expected_secret` with Python's secure `secrets.compare_digest` function. Added a check for `None` to prevent `TypeError`.
2. Modified the catch block from `except Exception as e:` to `except Exception:`, catching the error to log internally using Python's standard `logging` library with `exc_info=True` for debugging, while serving a sanitized, generic 500 error response to the client.

✅ **Verification:** 
- Reviewed the modifications using manual verification (`cat`, `diff`).
- Ran Python linters (`uv run ruff check`) to ensure valid formatting and module-level import locations.
- Ran backend pytest suite, observing the same passing/failing state as pre-patch tests, ensuring no logic regressions were introduced.

---
*PR created automatically by Jules for task [13062859209899411874](https://jules.google.com/task/13062859209899411874) started by @ivanleekk*