### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and info disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-06-27 - Information disclosure and Timing Attacks
+**Vulnerability:** Fast fail on string comparison for secrets opens up timing attacks. Stack traces or exception messages in 500 errors leak system internals.
+**Learning:** Checking optional header dependencies with `secrets.compare_digest` requires an explicit `None` check to avoid runtime type errors. Replacing `str(e)` with a generic message requires internal logging (`exc_info=True`) to maintain observability.
+**Prevention:** Use `secrets.compare_digest` for all secret comparisons, taking care to handle `None` values correctly. Provide generic HTTP 500 responses and log the actual exceptions.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -3,10 +3,15 @@ from sqlalchemy.orm import Session
 from datetime import date
 import os
 
+import secrets
+import logging
+
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +23,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +59,9 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        logger.error("Error in scheduled_snapshot_job", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The internal scheduler API (`/internal/tasks/daily-snapshot`) had two security issues: 
1. It used a standard string equality check (`!=`) for a secret token in a custom HTTP Header, opening it up to timing attacks.
2. The endpoint’s generic exception handler returned the raw exception string (`str(e)`) in a 500 error response, potentially leaking internal implementation details (e.g., database connection strings, file paths) to the client.

🎯 **Impact:** 
- An attacker could theoretically exploit the timing attack to guess the `SCHEDULER_SECRET` character by character.
- The information disclosure could aid an attacker by revealing sensitive system internals upon triggering unexpected errors.

🔧 **Fix:** 
- Replaced the `!=` check with `secrets.compare_digest` for constant-time comparison to prevent timing attacks, adding an explicit `is None` check to prevent runtime type errors if the header is omitted.
- Updated the generic exception handler to return a standard "An internal server error occurred" message to the client, while utilizing `logger.error("...", exc_info=True)` to internally record the stack trace and maintain observability.

✅ **Verification:** 
- The modifications in `backend/src/routers/internal.py` have been verified.
- The Python code has been successfully linted (`uv run ruff check src/routers/internal.py`).

---
*PR created automatically by Jules for task [16789968966607745194](https://jules.google.com/task/16789968966607745194) started by @ivanleekk*