### PR TITLE
🎨 Palette: Improve Dialog accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -20,16 +20,20 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
             {/* Backdrop */}
             <div
+                aria-hidden="true"
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
                     onClick={onClose}
+                    aria-label="Close"
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >
                     <X className="h-5 w-5" />


### PR DESCRIPTION
💡 **What:** Added standard accessibility (a11y) attributes (`aria-hidden`, `role`, `aria-modal`, and `aria-label`) to the `Dialog` component.
🎯 **Why:** To make custom modals natively accessible to screen readers, ensuring the backdrop is ignored, the modal container is properly recognized, and the close button is explicitly labeled.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Added `aria-hidden="true"` to the dialog backdrop. Added `role="dialog"` and `aria-modal="true"` to the main modal container. Added `aria-label="Close"` to the icon-only close button.

---
*PR created automatically by Jules for task [15118380983164708432](https://jules.google.com/task/15118380983164708432) started by @ivanleekk*