### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Timing Attack in Scheduler Secret Validation

### DIFF
--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,6 +2,7 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
@@ -18,7 +19,9 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    # SECURITY: Prevent timing attacks by using constant-time comparison.
+    # Check for None first to avoid TypeError in compare_digest.
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Timing attack vulnerability in the internal task scheduler due to standard string equality comparison (`!=`) for a secret header (`x_scheduler_secret`).
🎯 Impact: Attackers could potentially deduce the scheduler secret character by character by measuring the response times of the server.
🔧 Fix: Replaced standard string comparison with constant-time comparison `secrets.compare_digest()`. Added a `None` check before comparison to prevent `TypeError` exceptions which could cause unintentional 500 errors.
✅ Verification: Ran `ruff check src/routers/internal.py` and it passed. Re-ran backend tests without introducing any new failures.

---
*PR created automatically by Jules for task [13574772256673558941](https://jules.google.com/task/13574772256673558941) started by @ivanleekk*