### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information disclosure and timing attack in internal router

### DIFF
--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import logging
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +22,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +58,9 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        logger.error("Internal server error during scheduled snapshot job", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** 
1. **Timing Attack:** `x_scheduler_secret != expected_secret` used a standard string comparison, which can leak the length or partial contents of the secret via timing analysis.
2. **Information Disclosure:** The catch-all `except Exception as e:` block returned `detail=str(e)` to the client, potentially exposing sensitive stack traces or internal server state during a crash.

🎯 **Impact:** Attackers could theoretically brute-force the scheduler secret, or gain internal context about the application's infrastructure via detailed error messages, allowing them to escalate attacks or bypass the secret check entirely.

🔧 **Fix:** 
1. Used `secrets.compare_digest` for constant-time string comparison to mitigate the timing attack, ensuring the header is handled safely even if it's `None`.
2. Changed exception handling to fail securely by returning a generic 500 error string ("An internal server error occurred") and moving the actual exception details to internal server logs via `logging.error(..., exc_info=True)`.

✅ **Verification:** Verified changes via linter `uv run ruff check` passing and reviewing the applied patch to ensure the exceptions are caught and generic errors are sent while logging the stack trace internally.

---
*PR created automatically by Jules for task [4493249087273081213](https://jules.google.com/task/4493249087273081213) started by @ivanleekk*