### PR TITLE
🎨 Palette: [UX improvement] Improve Dialog accessibility

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -20,15 +20,19 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
             {/* Backdrop */}
             <div
+                aria-hidden="true"
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    aria-label="Close dialog"
                     onClick={onClose}
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >


### PR DESCRIPTION
**💡 What**
Added standard ARIA attributes (`aria-hidden="true"`, `role="dialog"`, `aria-modal="true"`) to the modal and backdrop layers, and an `aria-label` to the icon-only close button in the `Dialog` component.

**🎯 Why**
Previously, the custom Dialog component lacked proper WAI-ARIA roles, meaning screen readers and other assistive technologies would not correctly interpret the component as a modal dialog, and users could not easily identify the purpose of the close button. 

**📸 Before/After**
N/A - This is an invisible, under-the-hood improvement for assistive tech.

**♿ Accessibility**
- Added `aria-hidden="true"` to the backdrop so screen readers ignore it.
- Added `role="dialog"` and `aria-modal="true"` to the modal container to announce it as an interactive dialog overlay.
- Added `aria-label="Close dialog"` to the close `<button>` (which previously only contained the `X` icon).

---
*PR created automatically by Jules for task [16761979786996310742](https://jules.google.com/task/16761979786996310742) started by @ivanleekk*