### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and info disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Timing Attacks and Info Disclosure in Internal Router
+**Vulnerability:** The internal router used standard string equality (`!=`) for secret comparison, making it vulnerable to timing attacks. It also exposed full exception details (`str(e)`) via HTTPException on errors, risking information disclosure.
+**Learning:** FastAPI dependency headers are strings, and when checking against expected secrets, constant-time comparison must be used. Additionally, returning `str(e)` in HTTP responses leaks sensitive server internals.
+**Prevention:** Always use `secrets.compare_digest` (after checking for None) for sensitive string comparisons. Catch generic exceptions without exposing the variable to the user; instead, log the error internally (`exc_info=True`) and return a generic 500 error message.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import secrets
+import logging
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +22,7 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +58,9 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        logger.error("Internal server error during scheduled snapshot job", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity**: HIGH

💡 **Vulnerability**: 
1. The `verify_scheduler_secret` dependency used standard string equality (`!=`) for token comparison, which is vulnerable to timing attacks.
2. The `scheduled_snapshot_job` endpoint caught generic exceptions and returned `detail=str(e)` in the 500 HTTP response, which could disclose sensitive server internal details, stack traces, or configuration errors to an attacker.

🎯 **Impact**: 
1. Attackers could potentially forge the scheduler secret byte-by-byte by analyzing server response times.
2. Attackers triggering errors in the snapshot job could gain deep insight into database structures, query logic, or external service configurations, aiding further attacks.

🔧 **Fix**: 
1. Updated `verify_scheduler_secret` to use `secrets.compare_digest` for constant-time string comparison (after safely checking for `None`).
2. Updated `scheduled_snapshot_job` to catch the generic `Exception`, log it internally using `logger.error("...", exc_info=True)` for debugging, and return a sanitized, generic 500 error to the client.

✅ **Verification**: 
1. Visually verified the code changes to ensure logic is correct.
2. Ran `uv run ruff check src/routers/internal.py` to ensure no linting errors.
3. Tests run without regressions.

---
*PR created automatically by Jules for task [17647889293721990540](https://jules.google.com/task/17647889293721990540) started by @ivanleekk*