### PR TITLE
🎨 Palette: [Accessibility] Improve Dialog component screen reader support

### DIFF
--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -22,15 +22,19 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
             <div
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
+                aria-hidden="true"
             />
 
             {/* Modal */}
             <div
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
+                role="dialog"
+                aria-modal="true"
             >
                 <button
                     onClick={onClose}
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
+                    aria-label="Close"
                 >
                     <X className="h-5 w-5" />
                 </button>


### PR DESCRIPTION
### 💡 What
Improved the accessibility of the `Dialog` component by adding appropriate ARIA attributes for screen readers.

### 🎯 Why
Screen reader users need context when interacting with custom modals. Without these attributes, screen readers may read background content when a modal is open, fail to announce the container as a dialog, or misinterpret the icon-only close button.

### 📸 Before/After
No visual changes.

### ♿ Accessibility
- Added `aria-hidden="true"` to the modal backdrop overlay to prevent screen readers from announcing it.
- Added `role="dialog"` and `aria-modal="true"` to the modal container to trap focus virtually and announce the element as a dialog.
- Added `aria-label="Close"` to the icon-only dismiss `<button>`.

---
*PR created automatically by Jules for task [7428669541806484063](https://jules.google.com/task/7428669541806484063) started by @ivanleekk*