### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and information disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Timing Attack and Information Disclosure in Internal Router
+**Vulnerability:** The internal router compared secrets using the `!=` operator, creating a timing attack vulnerability. Additionally, an unhandled exception was being returned directly to the user via `str(e)`, causing information disclosure.
+**Learning:** Python's standard equality operators perform short-circuit evaluation, leaking the length of matching characters through execution time. Exposing raw exception details can leak system internals or stack traces.
+**Prevention:** Always use `secrets.compare_digest` for secret or signature comparisons and verify the input is not `None`. Never return raw exception strings (`str(e)`); log the error internally with `exc_info=True` and return a generic error message to the client.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import logging
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +22,8 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
+        # Use secure comparison to prevent timing attacks
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +59,10 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        # Do not expose internal error details to the client
+        logger.error("Internal snapshot job failed", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Internal server error occurred while processing snapshots."
         )


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability: 
1. The `verify_scheduler_secret` dependency compared the incoming secret with the environment variable using the `!=` operator, which can be vulnerable to timing attacks.
2. The `/tasks/daily-snapshot` endpoint caught a generic `Exception` and leaked its raw details directly back to the client using `str(e)`.

🎯 Impact:
1. An attacker could potentially guess the scheduler secret character by character by measuring the exact time it takes the server to reject incorrect tokens.
2. An internal server error during the snapshot job could leak sensitive internal system details or stack traces to unauthorized parties.

🔧 Fix:
1. Replaced the standard equality check `!=` with `secrets.compare_digest` for constant-time secret comparison to prevent timing attacks. Included a check to ensure `x_scheduler_secret` is not `None` to avoid `TypeError`.
2. Changed the exception block from `except Exception as e:` to `except Exception:`. Raw details are now logged internally with full stack traces (`exc_info=True`), and a generic error message is returned to the client to avoid info leakage.

✅ Verification:
- Ran `uv run pytest` to ensure no related tests failed.
- Executed `uv run ruff check` to confirm no new linting errors were introduced.

---
*PR created automatically by Jules for task [16935554281326052438](https://jules.google.com/task/16935554281326052438) started by @ivanleekk*