### PR TITLE
🎨 Palette: Improve Dialog accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-02 - Dialog Accessibility Improvement
+**Learning:** Custom modal components often miss crucial ARIA attributes (`role="dialog"`, `aria-modal="true"`) and background hiding (`aria-hidden="true"` on backdrop), leading to a poor screen reader experience. Icon-only buttons inside them also frequently lack `aria-label`s.
+**Action:** When creating or reviewing custom Dialog/Modal components, always ensure they include proper ARIA roles and labels, especially for structural containers and icon-only close buttons.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -20,16 +20,20 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
             {/* Backdrop */}
             <div
+                aria-hidden="true"
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
                     onClick={onClose}
+                    aria-label="Close dialog"
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >
                     <X className="h-5 w-5" />


### PR DESCRIPTION
**💡 What:**
Added critical ARIA attributes to the custom `Dialog` component in `frontend/src/components/ui/Dialog.tsx`.
- Added `role="dialog"` and `aria-modal="true"` to the modal container.
- Added `aria-hidden="true"` to the backdrop to hide it from screen readers.
- Added `aria-label="Close dialog"` to the icon-only close `<button>`.

**🎯 Why:**
Custom modal components require specific ARIA attributes to be properly announced and interacted with by screen readers. Without these, visually impaired users may not realize a modal has opened, may get lost navigating the background content, or won't know what the icon-only close button does.

**📸 Before/After:**
*(Visuals remain unchanged, this is an underlying HTML structure improvement)*

**♿ Accessibility:**
This change significantly improves the accessibility of all modals across the application for users relying on assistive technologies, ensuring they comply with WAI-ARIA authoring practices for dialogs.

---
*PR created automatically by Jules for task [11781407993200268815](https://jules.google.com/task/11781407993200268815) started by @ivanleekk*