### PR TITLE
🛡️ Sentinel: [HIGH] Fix timing attack and information disclosure in internal router

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,10 @@
+## 2024-10-24 - Timing Attacks in Optional Headers and Exception Information Disclosure
+**Vulnerability:**
+1. Timing attack in scheduler secret verification due to using standard `!=` string comparison instead of a constant-time check.
+2. Information disclosure by leaking raw exception details (`str(e)`) to the client during a 500 Internal Server Error.
+**Learning:**
+1. When comparing optional headers (`Header(None)`) with `secrets.compare_digest`, a `None` value can cause runtime type errors.
+2. Removing raw exception details might cause linting issues like Ruff's `F841` if `except Exception as e:` isn't changed to `except Exception:`.
+**Prevention:**
+1. Always check if an optional string dependency is `None` before passing it to `secrets.compare_digest`.
+2. When replacing `str(e)` with a generic message, explicitly change the exception block to `except Exception:` and log the original exception using `logger.error(..., exc_info=True)` for system observability.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,15 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import logging
+import secrets
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -18,7 +22,8 @@ def verify_scheduler_secret(x_scheduler_secret: str = Header(None)):
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Server configuration error: SCHEDULER_SECRET not set"
         )
-    if x_scheduler_secret != expected_secret:
+    # SECURITY: Prevent timing attacks when verifying the secret
+    if x_scheduler_secret is None or not secrets.compare_digest(x_scheduler_secret, expected_secret):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Invalid scheduler secret"
@@ -54,8 +59,10 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 results.append({"household_id": hh_id, "status": "no_data"})
                 
         return {"status": "success", "processed": len(results), "details": results}
-    except Exception as e:
+    except Exception:
+        # SECURITY: Log exception internally without leaking details to the client
+        logger.error("Error running daily snapshot task", exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred while processing snapshots"
         )


### PR DESCRIPTION
🚨 Severity: HIGH

💡 Vulnerability:
1. The scheduler secret verification was using a standard string comparison `!=`, which is susceptible to timing attacks.
2. The catch-all exception block for daily snapshots was leaking raw stack traces/details `str(e)` to the client, leading to information disclosure.

🎯 Impact:
1. An attacker could potentially infer the secret character-by-character based on the response time.
2. An attacker could gain internal knowledge about the database or server state via error messages.

🔧 Fix:
1. Replaced the `!=` comparison with `secrets.compare_digest` for constant-time comparison, handling cases where the secret is None.
2. Stripped `str(e)` from the `HTTPException` detail, replacing it with a generic error message, and implemented `logger.error` to keep the original stack trace on the server side for observability.

✅ Verification:
Ran `ruff check` on the internal router and backend test suite successfully, verifying that the fix introduces no linting errors or regressions.

---
*PR created automatically by Jules for task [9391083385620331828](https://jules.google.com/task/9391083385620331828) started by @ivanleekk*