### PR TITLE
🎨 Palette: [Accessibility improvement] Enhance Dialog accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-07-03 - Dialog Accessibility Enhancements
+**Learning:** Adding standard ARIA modal attributes (`role="dialog"`, `aria-modal="true"`) to modal containers and explicitly hiding background backdrops (`aria-hidden="true"`) significantly improves screen reader navigation and helps correctly trap virtual focus.
+**Action:** Always ensure custom modal implementations include these essential ARIA attributes, as well as descriptive `aria-label` attributes on icon-only close buttons, to meet baseline accessibility standards.

--- a/frontend/src/components/ui/Dialog.tsx
+++ b/frontend/src/components/ui/Dialog.tsx
@@ -20,15 +20,19 @@ export function Dialog({ isOpen, onClose, children }: DialogProps) {
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6">
             {/* Backdrop */}
             <div
+                aria-hidden="true"
                 className="fixed inset-0 bg-base-900/40 backdrop-blur-sm transition-opacity animate-in fade-in duration-200"
                 onClick={onClose}
             />
 
             {/* Modal */}
             <div
+                role="dialog"
+                aria-modal="true"
                 className="relative w-full max-w-lg rounded-2xl bg-white dark:bg-base-900 p-6 shadow-2xl transition-all animate-in zoom-in-95 duration-200 border border-base-100 dark:border-base-800"
             >
                 <button
+                    aria-label="Close"
                     onClick={onClose}
                     className="absolute right-4 top-4 rounded-full p-2 text-base-400 hover:bg-base-50 dark:hover:bg-base-800 hover:text-base-600 dark:hover:text-base-100 transition-colors"
                 >


### PR DESCRIPTION
### 💡 What
Added essential ARIA attributes (`role="dialog"`, `aria-modal="true"`) to the modal container, `aria-hidden="true"` to the modal backdrop, and a descriptive `aria-label="Close"` to the icon-only close button within `frontend/src/components/ui/Dialog.tsx`.

### 🎯 Why
To improve the keyboard and screen reader accessibility of our custom Dialog component, ensuring it conforms to basic WAI-ARIA standards for modals and provides proper context for assistive technology users.

### 📸 Before/After
- **Before:** Modal lacked programmatic role identification; close button was announced merely as an unnamed button.
- **After:** Modal correctly traps virtual focus as a `dialog`; backdrop is hidden from screen readers; close button explicitly announces "Close".

### ♿ Accessibility
- `role="dialog"` and `aria-modal="true"` added to the primary modal content wrapper.
- `aria-hidden="true"` added to the overlaying backdrop.
- `aria-label="Close"` added to the `X` icon button.

---
*PR created automatically by Jules for task [4753620630914258469](https://jules.google.com/task/4753620630914258469) started by @ivanleekk*