### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix information disclosure in daily-snapshot

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Information Disclosure in Internal Snapshot Job
+**Vulnerability:** The internal `/tasks/daily-snapshot` endpoint returns the raw stringified exception (`str(e)`) in its 500 error response.
+**Learning:** Returning `str(e)` directly to API clients can inadvertently leak stack traces, database query structures, schema details, or other sensitive internal state information that an attacker could use for further exploitation.
+**Prevention:** Catch generic exceptions, log them securely internally (with stack traces via `exc_info=True`), and return generic error messages (e.g., "An internal server error occurred") to clients.

--- a/backend/src/routers/internal.py
+++ b/backend/src/routers/internal.py
@@ -2,11 +2,14 @@ from fastapi import APIRouter, Depends, HTTPException, Header, status
 from sqlalchemy.orm import Session
 from datetime import date
 import os
+import logging
 
 from src.database import get_db
 from src.models import Household, PortfolioSnapshot, Trade
 from sqlalchemy import select, func
 from src.services.snapshot_engine import run_snapshot_range
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/internal", tags=["Internal"])
 
@@ -55,7 +58,8 @@ def scheduled_snapshot_job(db: Session = Depends(get_db)):
                 
         return {"status": "success", "processed": len(results), "details": results}
     except Exception as e:
+        logger.error("Error in scheduled_snapshot_job: %s", e, exc_info=True)
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="An internal server error occurred"
         )


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The internal `/tasks/daily-snapshot` endpoint returned raw exception strings (`str(e)`) in its 500 HTTP response. This can inadvertently leak stack traces, internal paths, or database schema information to callers.
🎯 **Impact**: An attacker or unauthorized user could use detailed exception errors to map internal system state, understand query structures, or pivot for further exploitation.
🔧 **Fix**: Replaced the detailed exception output with a generic 'An internal server error occurred' message. Added python `logging` with `exc_info=True` to ensure the detailed exceptions are still preserved server-side for internal debugging. Kept `except Exception as e:` in order to log the error object `e` properly without raising ruff F841 warnings.
✅ **Verification**: Local linters (`ruff`) passed correctly, tests ran (ignoring pre-existing database failures in other modules), and the endpoint handles 500 errors gracefully.

---
*PR created automatically by Jules for task [15104005164348982879](https://jules.google.com/task/15104005164348982879) started by @ivanleekk*