### PR TITLE
🎨 Palette: Add ARIA labels to icon-only buttons

### DIFF
--- a/frontend/src/pages/Accounts/Accounts.tsx
+++ b/frontend/src/pages/Accounts/Accounts.tsx
@@ -583,7 +583,7 @@ export default function Accounts() {
                                     <CardTitle>Balance History: {historyAccount.name}</CardTitle>
                                     <CardDescription>Manual balance checkpoints for this account.</CardDescription>
                                 </div>
-                                <Button variant="ghost" size="sm" onClick={() => setIsHistoryModalOpen(false)}>✕</Button>
+                                <Button variant="ghost" size="sm" onClick={() => setIsHistoryModalOpen(false)} aria-label="Close history">✕</Button>
                             </CardHeader>
                             <CardContent className="overflow-y-auto pt-4">
                                 <div className="space-y-4">

--- a/frontend/src/pages/Household/Households.tsx
+++ b/frontend/src/pages/Household/Households.tsx
@@ -281,7 +281,7 @@ export default function Households() {
                                             </div>
                                         </div>
                                         {member.role !== 'owner' && (
-                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto">
+                                            <Button variant="ghost" onClick={() => handleRemoveMember(member.id)} className="text-red-500 hover:text-red-700 hover:bg-red-50 p-2 h-auto" aria-label="Remove member">
                                                 <Trash2 className="w-4 h-4" />
                                             </Button>
                                         )}

--- a/frontend/src/pages/Transactions/Transactions.tsx
+++ b/frontend/src/pages/Transactions/Transactions.tsx
@@ -611,6 +611,7 @@ export default function Transactions() {
                                             className="text-base-400 hover:text-red-600 hover:bg-red-50 h-8 w-8 p-0"
                                             onClick={() => handleDelete(item)}
                                             disabled={isDeleting === item.id}
+                                            aria-label="Delete transaction"
                                         >
                                             <Trash2 className="h-4 w-4" />
                                         </Button>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to icon-only buttons (close history button in Accounts, remove member button in Households, and delete transaction button in Transactions).
🎯 Why: To improve keyboard navigation and screen reader accessibility for interactive elements that lack visible text.
📸 Before/After: Visuals remain unchanged. Screen readers will now announce "Close history", "Remove member", and "Delete transaction" instead of unlabelled buttons.
♿ Accessibility: Ensures that users relying on assistive technologies understand the function of these buttons.

---
*PR created automatically by Jules for task [7754068726933743979](https://jules.google.com/task/7754068726933743979) started by @ivanleekk*