### PR TITLE
iOS: interactive charts, one pull gesture everywhere, safer row actions

### DIFF
--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -127,7 +127,44 @@ FinanceTracker/
 - All aggregate money displays use the household `baseCurrency` and the `*_home_currency` fields; per-account/per-asset detail uses native currency (same rule as web/mobile).
 - Private ownership (`owner_user_id != nil`) is rendered with a lock icon; the server already filters out other members' private data. Create forms (AccountFormView, GoalFormView) seed their Private toggle from the user's `default_new_items_private` in `.onAppear` (SessionStore isn't reachable from `init`), matching web.
     - `SubPortfolioUpdate.ownerUserId` is a `.unchanged` / `.set(String?)` enum with a hand-written `encode(to:)`, not a plain `String?`. The backend PATCH uses `exclude_unset`, so omitting the key leaves ownership alone while an explicit `null` clears it — a plain Optional can only express the first, which would make "Private → Shared" silently do nothing (the web UI has that limitation).
-- **The QuickAdd pull gesture** (`Components/QuickAddPull.swift`) needs two signals: `onScrollGeometryChange` for the overscroll distance, and a `.simultaneousGesture(DragGesture)` for finger down/up. `onScrollPhaseChange` is the API that _looks_ right, but on a `List` it only ever delivers `.idle` — no `.interacting`/`.decelerating` — so it cannot detect release. The bar opens only when the pull passes `trigger` (100pt of overscroll ≈ a 220pt pull) **and** the finger lifts below `flickVelocity` (1200 pt/s); momentum-only overscroll never arms it. Both halves matter — without the velocity check a fast flick from the top still opens it, which is what "too sensitive" meant.
+- **Gestures come in pairs, and destructive ones confirm.** Every swipe action on a row is
+  mirrored by a `.contextMenu` carrying the same items — a swipe is invisible until you try it
+  and is out of reach of Voice Control and Switch Control, so it can never be the only path to
+  an action. Anything irreversible (delete a transaction / trade / budget / category, remove a
+  household member) uses `.swipeActions(allowsFullSwipe: false)` plus a `.confirmationDialog`,
+  never `.onDelete` — a full swipe must reveal the button, not commit. The dialog's state lives
+  on the **screen**, not the row: a dialog presented from inside a swipe-actions row is torn
+  down with the row's own collapse animation before it is ever shown. Cancelling an invite is
+  the deliberate exception (re-inviting undoes it), so it keeps a plain swipe.
+- **The QuickAdd pull gesture** (`Components/QuickAddPull.swift`) needs two signals: `onScrollGeometryChange` for the overscroll distance, and a `.simultaneousGesture(DragGesture)` for finger down/up. `onScrollPhaseChange` is the API that _looks_ right, but on a `List` it only ever delivers `.idle` — no `.interacting`/`.decelerating` — so it cannot detect release. The bar opens when the pull passes `trigger` (100pt of overscroll ≈ a 220pt pull) and the finger then lifts without flicking back *up* faster than `retractVelocity` (900 pt/s). It is the release **direction** that decides, not its speed: still moving down, or roughly still, completes the gesture the "Release for Quick Add" badge just promised, and a confident fast pull is the most deliberate version of that, not the least — only a sharp flick upward reads as taking it back. Momentum-only overscroll can't arm it at all, because `dragging` (set by the `DragGesture`, cleared on end *and* when the sheet opens) gates every update.
+  It is on **every browse screen** — the five tabs, the pushed detail screens (account, goal,
+  loan schedule, sub-portfolio), and the More-tab pages (Budgets, Categories, Recurring,
+  Reports, Members). It fully replaces `.refreshable`, which no longer appears anywhere: the
+  same downward pull had to mean the same thing on every screen, and two different meanings
+  split by "main tab vs. More tab" was a distinction only the code could see. Screens refetch
+  on `.task` and on `QuickAddStore.reloadToken`; there is no manual refresh control. Modal
+  sheets and edit forms deliberately have no pull — interrupting a half-filled form with
+  another modal is not a gesture anyone wants.
+- **Charts are interactive, through `Views/Components/ChartStyle.swift`.** Time-series charts
+  (Dashboard net worth, `GrowthChart`, the goal projection, an account's balance) take
+  `.chartScrub(selection:readout:)`: the caller owns the `Date?` the gesture writes and
+  resolves a `ChartScrubReadout` from it with `ChartStyle.nearest` (curves are *binned*, so the
+  finger lands between points far more often than on one), and the modifier draws the rule and
+  the dots and ticks a `.selection` haptic per datum. Readouts go in a `ChartScrubCaption`
+  beside the plot, not a floating tooltip — a bubble covers the data being asked about and has
+  to be measured and clamped every frame. The Dashboard goes further and rewrites its own
+  headline figure, date label and Cash/Investments cells from the scrub instead of adding a
+  caption. Donuts (Net Worth Split, Allocation, Top Categories) use `.chartAngleSelection` +
+  `ChartStyle.sliceIndex`, which resolves the *cumulative* angle the API reports back to a
+  slice; the picked wedge grows outward and the rest dim, the donut's centre reads it out, and
+  the legend rows are buttons that select the same wedge (a thin sector is a poor touch target
+  and the only accessible way in).
+- **Known gap — interactive dismissal.** No form uses `interactiveDismissDisabled`, so dragging
+  a sheet down discards a half-filled trade / transaction / account form with no prompt. Fixing
+  it needs per-form dirty tracking plus a "Discard changes?" confirmation dialog on every
+  create/edit sheet (`TransactionFormView`, `TradeFormView`, `AccountFormView`, `GoalFormView`,
+  `BudgetFormView`, `RecurringFormView`, `QuickAddView`); do it as one pass so the behaviour is
+  uniform, not sheet by sheet.
 - **API base URL** resolves in `APIClient.baseURL` via `AppConfig.defaultBaseURL`, which reads the `API_BASE_URL` Info.plist key (fed by the per-configuration `API_BASE_URL` build setting in `project.yml`, `$(API_BASE_URL)`; falls back to `http://localhost:8000`). **Debug builds only** additionally honour a runtime override (`UserDefaults` key `api_base_url`, editable in the More tab and on the login screen) for physical-device/LAN testing — the whole override (UI + read path) is wrapped in `#if DEBUG`, so it compiles out of Release/production builds. To ship against a real backend, set the Release `API_BASE_URL` build setting. ATS is opened for local networking only (`NSAllowsLocalNetworking`).
 - **View mode (Private/Household/Blended)** mirrors the web `ViewModeContext`. `ViewModeStore` (`State/ViewModeStore.swift`, app-root environment) holds the persisted mode + a `hasSecondPerson` flag; the `ViewModeSwitcher` toolbar control (`Views/Components/`) renders only once the active household has a second person (member beyond owner, or a pending invite — refreshed on household change in `MainTabView` and after invite changes via `setComposition`). `isVisible(ownerUserId:currentUserId:)` filters accounts/sub-portfolios (and their balances/holdings/transactions) on Dashboard, Accounts, Portfolio, and Transactions. Solo households always render `blended` (everything the user owns), so filtering is a no-op until a second person exists.
 - **Face ID vault lock** (`require_face_id_for_vault`, an existing backend field that neither the web nor mobile surfaced) is enforced only on iOS. `ViewModeStore` also owns the vault state: `configureVault(requireFaceId:)` (called from `MainTabView` on login / when the user record's flag changes) caches `BiometricAuth.isAvailable`; while `isVaultLocked` (setting on **and** device can authenticate **and** not yet unlocked), `isVisible` hides **all** private items regardless of view mode. Unlock is `LocalAuthentication` via `Support/BiometricAuth.swift` using `.deviceOwnerAuthentication` (Face ID / Touch ID with passcode fallback). **It fails open**: a device with no biometrics/passcode can't lock, so users are never shut out of their own data. `MainTabView` auto-prompts once on login/foreground and re-locks on `.background` (guarding against `.inactive`, since the biometric sheet itself makes the app inactive — locking there would loop). The `VaultLockButton` toolbar control shows a lock/unlock affordance when the feature is active. Note the backend **defaults this field to `true`**, so once enforced, every user's private vault is biometric-gated by default (the preview test user was flipped to `false` locally so browser/simulator verification isn't blocked by the prompt).

--- a/ios/FinanceTracker/Support/Formatters.swift
+++ b/ios/FinanceTracker/Support/Formatters.swift
@@ -63,6 +63,12 @@ extension Date {
         formatted(.dateTime.month(.wide).year().utc)
     }
 
+    /// "24 Jul 26" — the chart-scrub readout. Carries the year that `shortDay` omits,
+    /// because a scrubbable chart routinely spans several of them.
+    var scrubDay: String {
+        formatted(.dateTime.day().month(.abbreviated).year(.twoDigits).utc)
+    }
+
     /// "yyyy-MM-dd" in UTC, for backend `date`-typed fields. Pydantic's `date`
     /// rejects a datetime with a non-zero time, and DatePicker carries the current
     /// time-of-day — so date-only bodies must send a bare date string. UTC matches

--- a/ios/FinanceTracker/Views/Accounts/AccountsView.swift
+++ b/ios/FinanceTracker/Views/Accounts/AccountsView.swift
@@ -147,6 +147,7 @@ struct AccountsListView: View {
 
 struct AccountDetailView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
 
     let account: AccountResponse
     /// Called after a change so the parent list (and net worth) reload.
@@ -166,6 +167,8 @@ struct AccountDetailView: View {
     /// because the detail screen can be pushed straight from the Dashboard,
     /// without the accounts list ever having loaded.
     @State private var propertyAccounts: [AccountResponse] = []
+    /// Where the finger is on the balance chart, or nil when nobody is scrubbing.
+    @State private var chartScrubDate: Date?
 
     var body: some View {
         List {
@@ -183,6 +186,16 @@ struct AccountDetailView: View {
 
             if sorted.count > 1 {
                 Section {
+                    let readout = chartScrubDate
+                        .flatMap { ChartStyle.nearest(to: $0, in: sorted, by: \.date) }
+                        .map { point in
+                            ChartScrubReadout(
+                                date: point.date,
+                                entries: [ChartScrubEntry(label: "Balance", value: point.balance,
+                                                          color: session.theme.primary.accent,
+                                                          markerY: point.balance)]
+                            )
+                        }
                     Chart(sorted) { balance in
                         AreaMark(
                             x: .value("Date", balance.date),
@@ -202,8 +215,13 @@ struct AccountDetailView: View {
                         currency: account.currency,
                         dateSpan: sorted.last?.date.timeIntervalSince(sorted[0].date)
                     )
+                    .chartScrub(selection: $chartScrubDate, readout: readout)
                     .adaptiveChartHeight(compact: 160, regular: 280)
                     .padding(.vertical, 4)
+
+                    ChartScrubCaption(readout: readout, currency: account.currency,
+                                      selection: $chartScrubDate)
+                        .listRowSeparator(.hidden)
                 }
             }
 
@@ -261,6 +279,7 @@ struct AccountDetailView: View {
         .overlay {
             if isLoading && balances.isEmpty { ProgressView() }
         }
+        .quickAddPull(quickAdd, onReload: reload)
         .task { await reload() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },

--- a/ios/FinanceTracker/Views/Accounts/LoanScheduleView.swift
+++ b/ios/FinanceTracker/Views/Accounts/LoanScheduleView.swift
@@ -55,6 +55,8 @@ struct EquityRow: View {
 /// Loaded on demand — a 30-year mortgage is 360 rows, which is not worth
 /// fetching with the accounts list.
 struct LoanScheduleView: View {
+    @Environment(QuickAddStore.self) private var quickAdd
+
     let account: AccountResponse
 
     @State private var schedule: LoanScheduleResponse?
@@ -136,6 +138,7 @@ struct LoanScheduleView: View {
                 )
             }
         }
+        .quickAddPull(quickAdd, onReload: load)
         .task { await load() }
     }
 

--- a/ios/FinanceTracker/Views/Budgets/BudgetsView.swift
+++ b/ios/FinanceTracker/Views/Budgets/BudgetsView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// long would I last if the income stopped".
 struct BudgetsView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
 
     @State private var status: BudgetStatusResponse?
     @State private var fund: EmergencyFundResponse?
@@ -15,6 +16,10 @@ struct BudgetsView: View {
     @State private var showingAddBudget = false
     @State private var editingBudget: BudgetStatusRow?
     @State private var errorMessage: String?
+    // Confirmation state lives on the screen, not the row: a dialog presented from
+    // inside a swipe-actions row is torn down with the row's own collapse animation
+    // before it ever appears (same reason RecurringView keeps it here).
+    @State private var pendingDelete: BudgetStatusRow?
 
     private var currency: String {
         status?.baseCurrency ?? session.activeHousehold?.baseCurrency ?? "USD"
@@ -54,16 +59,33 @@ struct BudgetsView: View {
 
             Section("Budgets") {
                 ForEach(rows) { row in
-                    BudgetRowView(row: row, currency: currency)
-                        .contentShape(Rectangle())
-                        .onTapGesture { editingBudget = row }
-                        .swipeActions {
-                            Button(role: .destructive) {
-                                Task { await delete(row) }
-                            } label: {
-                                Label("Delete", systemImage: "trash")
-                            }
+                    // A Button, not `.onTapGesture` — a bare tap gesture gives the row
+                    // no press highlight and no button trait for VoiceOver, so the row
+                    // looks inert right up until the sheet appears.
+                    Button { editingBudget = row } label: {
+                        BudgetRowView(row: row, currency: currency)
+                    }
+                    .buttonStyle(.plain)
+                    // `allowsFullSwipe: false`: deleting a budget is a server-side
+                    // delete with no undo, so the swipe reveals the button and the
+                    // confirmation is the only path through.
+                    .swipeActions(allowsFullSwipe: false) {
+                        Button(role: .destructive) {
+                            pendingDelete = row
+                        } label: {
+                            Label("Delete", systemImage: "trash")
                         }
+                    }
+                    // Same actions on a long press: a swipe is invisible until you try
+                    // it, and unreachable from Voice Control / Switch Control.
+                    .contextMenu {
+                        Button { editingBudget = row } label: {
+                            Label("Edit", systemImage: "pencil")
+                        }
+                        Button(role: .destructive) { pendingDelete = row } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
                 }
                 if rows.isEmpty && !isLoading {
                     Text("No budgets yet. Tap + to cap a category.")
@@ -92,7 +114,7 @@ struct BudgetsView: View {
         .overlay {
             if isLoading && status == nil { LoadingSkeleton() }
         }
-        .refreshable { await load() }
+        .quickAddPull(quickAdd, onReload: load)
         .task { await load() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },
@@ -101,6 +123,22 @@ struct BudgetsView: View {
             Button("OK", role: .cancel) {}
         } message: {
             Text(errorMessage ?? "")
+        }
+        .confirmationDialog(
+            "Delete this budget?",
+            isPresented: .init(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let row = pendingDelete {
+                    Task { await delete(row) }
+                }
+            }
+        } message: {
+            Text("The transactions in it stay — only the cap is removed.")
         }
     }
 

--- a/ios/FinanceTracker/Views/Components/ChartStyle.swift
+++ b/ios/FinanceTracker/Views/Components/ChartStyle.swift
@@ -163,3 +163,184 @@ extension View {
             }
     }
 }
+
+// MARK: - Scrubbing
+
+/// One line of a scrub readout: what was read, in what colour, and — when the value
+/// sits on a plotted line — where its dot belongs in data space.
+struct ChartScrubEntry {
+    let label: String
+    let value: Double
+    let color: Color
+    /// Data-space y for the marker dot. `nil` for a derived figure (a total) that isn't
+    /// itself a line on the chart, so there's nothing on the plot to point at.
+    var markerY: Double?
+}
+
+/// What the finger is currently over on a time-series chart.
+struct ChartScrubReadout: Equatable {
+    let date: Date
+    let entries: [ChartScrubEntry]
+
+    /// Only the date matters for equality — it's what drives the haptic and the redraw,
+    /// and the entries are a pure function of it.
+    static func == (lhs: Self, rhs: Self) -> Bool { lhs.date == rhs.date }
+}
+
+extension ChartStyle {
+    /// The datum nearest a scrub position. Curves are sampled (daily / weekly / monthly
+    /// bins), so the finger lands *between* points far more often than on one, and
+    /// snapping to the nearest is what makes the dot sit on the line instead of floating
+    /// beside it.
+    static func nearest<T>(
+        to date: Date,
+        in points: [T],
+        by keyPath: KeyPath<T, Date>
+    ) -> T? {
+        points.min {
+            abs($0[keyPath: keyPath].timeIntervalSince(date))
+                < abs($1[keyPath: keyPath].timeIntervalSince(date))
+        }
+    }
+
+    /// Which slice a donut's angle selection landed in. `chartAngleSelection` reports the
+    /// *cumulative* angle value, not an identity, so resolving it means walking the same
+    /// running total the sectors were laid out from — in the same order they were plotted.
+    static func sliceIndex(
+        atAngleValue value: Double?,
+        in values: [Double]
+    ) -> Int? {
+        guard let value else { return nil }
+        var running = 0.0
+        for (index, slice) in values.enumerated() {
+            running += slice
+            if value <= running { return index }
+        }
+        return values.isEmpty ? nil : values.count - 1
+    }
+}
+
+private struct ChartScrubModifier: ViewModifier {
+    @Binding var selection: Date?
+    let readout: ChartScrubReadout?
+
+    /// What Swift Charts reports *while* the finger is down. It clears this the instant
+    /// the finger lifts, which is wrong for a money chart: you look a date up in order to
+    /// read it, and a number that vanishes on release can't be read at all. The live
+    /// value is copied into `selection` and stays there until the next scrub or an
+    /// explicit clear, so the binding the caller owns is the sticky one.
+    @State private var live: Date?
+
+    func body(content: Content) -> some View {
+        content
+            .chartXSelection(value: $live)
+            .onChange(of: live) { _, new in
+                if let new { selection = new }
+            }
+            .chartOverlay { proxy in
+                GeometryReader { geo in
+                    if let readout,
+                       let anchor = proxy.plotFrame,
+                       let dx = proxy.position(forX: readout.date) {
+                        let plot = geo[anchor]
+                        let x = plot.minX + dx
+
+                        Rectangle()
+                            .fill(.primary.opacity(0.25))
+                            .frame(width: 1, height: plot.height)
+                            .position(x: x, y: plot.midY)
+
+                        ForEach(Array(readout.entries.enumerated()), id: \.offset) { _, entry in
+                            if let markerY = entry.markerY,
+                               let dy = proxy.position(forY: markerY) {
+                                // Surface-coloured ring, the same trick the "you are
+                                // here" marker uses: the dot has to stay legible sitting
+                                // on top of its own line.
+                                Circle()
+                                    .fill(ChartStyle.surface)
+                                    .frame(width: 14, height: 14)
+                                    .overlay {
+                                        Circle().fill(entry.color).frame(width: 9, height: 9)
+                                    }
+                                    .position(x: x, y: plot.minY + dy)
+                            }
+                        }
+                    }
+                }
+                // The overlay is a readout, never a target — hit testing here would
+                // swallow the very drag that's driving it.
+                .allowsHitTesting(false)
+            }
+            // One detent per datum, the way a picker ticks. `.selection` and not
+            // `.impact`: nothing was committed, the reading just moved.
+            .sensoryFeedback(.selection, trigger: readout?.date)
+    }
+}
+
+extension View {
+    /// Make a time-series chart scrubbable: drag across it to read any point.
+    ///
+    /// The caller owns both halves — the `Date?` the gesture writes, and the readout it
+    /// resolves from that date (usually via `ChartStyle.nearest`) — because only the
+    /// call site knows which series it plotted and what they mean. This adds the
+    /// gesture, the rule and dots on the plot, and the haptic; pair it with a
+    /// `ChartScrubCaption` (or wire the readout into the screen's own headline figure).
+    func chartScrub(
+        selection: Binding<Date?>,
+        readout: ChartScrubReadout?
+    ) -> some View {
+        modifier(ChartScrubModifier(selection: selection, readout: readout))
+    }
+}
+
+/// The scrub reading, as a caption row beside its chart.
+///
+/// Deliberately *not* a floating tooltip: a bubble inside the plot covers the very data
+/// the finger is asking about, and it has to be measured and clamped every frame to stay
+/// on screen. The row also reserves its height when nothing is selected, so starting a
+/// scrub never shifts the chart under the finger.
+struct ChartScrubCaption: View {
+    let readout: ChartScrubReadout?
+    let currency: String
+    /// The same binding passed to `chartScrub`, so the caption can clear the reading.
+    /// The selection sticks after the finger lifts, which means it also needs a way out.
+    @Binding var selection: Date?
+    /// Shown when nothing is selected, as the gesture's only affordance — a chart that
+    /// responds to a drag has no other way to say so.
+    var hint: String = "Drag the chart to read any date"
+
+    var body: some View {
+        HStack(spacing: 10) {
+            if let readout {
+                Text(readout.date.scrubDay)
+                    .foregroundStyle(.secondary)
+                ForEach(Array(readout.entries.enumerated()), id: \.offset) { _, entry in
+                    HStack(spacing: 4) {
+                        Circle()
+                            .fill(entry.color)
+                            .frame(width: 6, height: 6)
+                        Text(entry.value.currencyWhole(currency))
+                            .monospacedDigit()
+                    }
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("\(entry.label): \(entry.value.currencyWhole(currency))")
+                }
+                Spacer(minLength: 0)
+                Button { selection = nil } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Clear chart reading")
+            } else {
+                Text(hint)
+                    .foregroundStyle(.tertiary)
+                Spacer(minLength: 0)
+            }
+        }
+        .font(.caption.weight(.medium))
+        .lineLimit(1)
+        .minimumScaleFactor(0.75)
+        .frame(height: 16)
+    }
+}

--- a/ios/FinanceTracker/Views/Components/LoadingSkeleton.swift
+++ b/ios/FinanceTracker/Views/Components/LoadingSkeleton.swift
@@ -42,6 +42,7 @@ struct LoadingSkeleton: View {
 
 /// A diagonal highlight that sweeps across the view, clipped to its content.
 private struct Shimmer: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var phase: CGFloat = -1
 
     func body(content: Content) -> some View {
@@ -60,7 +61,11 @@ private struct Shimmer: ViewModifier {
                 .mask(content)
                 .allowsHitTesting(false)
             }
+            // A sweep that never stops is exactly the kind of looping motion Reduce
+            // Motion exists to switch off; the placeholder still reads as "loading"
+            // from its shape and the spinner-free skeleton itself.
             .onAppear {
+                guard !reduceMotion else { return }
                 withAnimation(.linear(duration: 1.25).repeatForever(autoreverses: false)) {
                     phase = 1
                 }

--- a/ios/FinanceTracker/Views/Components/QuickAddPull.swift
+++ b/ios/FinanceTracker/Views/Components/QuickAddPull.swift
@@ -22,6 +22,7 @@ struct QuickAddPullSensor: View {
 /// travel: ~100pt of overscroll ≈ a 220pt pull.
 private struct QuickAddPull: ViewModifier {
     @Environment(SessionStore.self) private var session
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     let store: QuickAddStore
     let onReload: () async -> Void
 
@@ -37,6 +38,13 @@ private struct QuickAddPull: ViewModifier {
 
     private var progress: CGFloat {
         min(1, max(0, (pull - deadZone) / (trigger - deadZone)))
+    }
+
+    /// The indicator retracting after the finger lifts is the one part of this gesture
+    /// that isn't finger-driven, so it's the one part that animates. Everything while a
+    /// finger is down tracks 1:1 — animating there would put lag between finger and badge.
+    private var retract: Animation {
+        reduceMotion ? .easeOut(duration: 0.2) : .spring(response: 0.3, dampingFraction: 0.85)
     }
 
     func body(content: Content) -> some View {
@@ -56,6 +64,14 @@ private struct QuickAddPull: ViewModifier {
                     .onEnded { value in release(velocity: value.velocity.height) }
             )
             .overlay(alignment: .top) { indicator }
+            // A drag that gets cancelled rather than ended (the sheet coming up over the
+            // list, a system gesture taking over) never reaches `onEnded`, which would
+            // leave `dragging` stuck true and let plain momentum overscroll arm the pull.
+            .onChange(of: store.isPresented) { _, _ in
+                dragging = false
+                armed = false
+                withAnimation(retract) { pull = 0 }
+            }
             .onChange(of: store.reloadToken) { _, _ in
                 Task { await onReload() }
             }
@@ -65,7 +81,7 @@ private struct QuickAddPull: ViewModifier {
         // Ignore everything that isn't finger-driven: a flick's rubber-band bounce used
         // to fire this the moment it crossed the threshold, with the finger already off.
         guard dragging else {
-            pull = 0
+            if pull != 0 { withAnimation(retract) { pull = 0 } }
             armed = false
             return
         }
@@ -76,26 +92,34 @@ private struct QuickAddPull: ViewModifier {
             UIImpactFeedbackGenerator(style: .light).impactOccurred()
         } else if armed, pull < trigger - 12 {
             // Hysteresis: easing back up past the threshold disarms without flapping.
+            // Disarming gets its own (softer) tick — the arm haptic promised something,
+            // and silently withdrawing the promise leaves the user guessing.
             armed = false
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
         }
     }
 
-    /// Finger lifted: open the command bar only if the pull was held past the threshold
-    /// *and* the finger had settled. A fast downward flick from the top of the list also
-    /// crosses the threshold, but it's a scroll gesture, not a deliberate pull — so
-    /// releasing at speed is ignored.
+    /// Finger lifted: open the command bar if the pull was held past the threshold.
+    ///
+    /// The release *direction* decides, not its speed. Still moving down, or roughly
+    /// still, means the pull stands — that's the gesture the "Release for Quick Add"
+    /// badge just promised, and a confident fast pull is the most deliberate version of
+    /// it, not the least. Only a sharp flick back *up* reads as taking it back. (Momentum
+    /// overscroll from scrolling can't reach here at all: `dragging` gates it above.)
     private func release(velocity: CGFloat) {
         dragging = false
-        pull = 0
-        guard armed else { return }
+        let wasArmed = armed
         armed = false
-        guard !store.isPresented, abs(velocity) < Self.flickVelocity else { return }
+        withAnimation(retract) { pull = 0 }
+        guard wasArmed, !store.isPresented else { return }
+        guard velocity > -Self.retractVelocity else { return }
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()
         store.open()
     }
 
-    /// Points/second at lift-off above which the gesture reads as a flick, not a pull.
-    private static let flickVelocity: CGFloat = 1200
+    /// Upward points/second at lift-off above which the release reads as pulling the
+    /// gesture back rather than completing it.
+    private static let retractVelocity: CGFloat = 900
 
     @ViewBuilder
     private var indicator: some View {
@@ -103,7 +127,7 @@ private struct QuickAddPull: ViewModifier {
             let ready = progress >= 1
             HStack(spacing: 7) {
                 Image(systemName: "plus.circle.fill")
-                    .rotationEffect(.degrees(Double(progress) * 180))
+                    .rotationEffect(.degrees(reduceMotion ? 0 : Double(progress) * 180))
                     .scaleEffect(ready ? 1.15 : 1)
                 Text(ready ? "Release for Quick Add" : "Keep pulling for Quick Add")
             }
@@ -117,8 +141,8 @@ private struct QuickAddPull: ViewModifier {
             .opacity(Double(min(1, progress * 1.4)))
             .offset(y: min(pull * 0.45, 54))
             .animation(.snappy(duration: 0.18), value: ready)
-            .transition(.opacity)
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
         }
     }
 }

--- a/ios/FinanceTracker/Views/Dashboard/DashboardView.swift
+++ b/ios/FinanceTracker/Views/Dashboard/DashboardView.swift
@@ -29,6 +29,8 @@ struct DashboardView: View {
     @State private var isLoading = true
     @State private var errorMessage: String?
     @State private var lastLoadedAt: Date?
+    /// Where the finger is on the net-worth chart, or nil when nobody is scrubbing.
+    @State private var netWorthScrub: Date?
 
     private var baseCurrency: String { session.activeHousehold?.baseCurrency ?? "USD" }
 
@@ -167,23 +169,56 @@ struct DashboardView: View {
         // instead of triggering it separately for the date-count gate and the
         // chart itself.
         let bands = netWorthBands
+        // Where the finger is on the net-worth chart, if anywhere. The whole card reads
+        // from this: headline figure, date label and both breakdown cells, so scrubbing
+        // rewrites the numbers the reader already knows rather than adding new ones.
+        let scrubbed = netWorthScrub.flatMap { ChartStyle.nearest(to: $0, in: bands, by: \.date) }
+        let scrubReadout: ChartScrubReadout? = scrubbed.map { point in
+            ChartScrubReadout(
+                date: point.date,
+                entries: [
+                    ChartScrubEntry(label: "Cash", value: point.cash,
+                                    color: ChartStyle.cash, markerY: point.cashTop),
+                    ChartScrubEntry(label: "Investments", value: point.investments,
+                                    color: ChartStyle.investments, markerY: point.investmentsTop),
+                ]
+            )
+        }
         NavigationStack {
             List {
                 QuickAddPullSensor()
                 Section {
                     VStack(alignment: .leading, spacing: 4) {
-                        Text("Net Worth")
-                            .font(.subheadline)
-                            .foregroundStyle(.secondary)
-                        Text(netWorth.currency(baseCurrency))
+                        HStack(spacing: 6) {
+                            Text(scrubbed.map(\.date.scrubDay) ?? "Net Worth")
+                                .font(.subheadline)
+                                .foregroundStyle(.secondary)
+                            // The reading sticks after the finger lifts (see
+                            // `chartScrub`), so it needs a way back to today.
+                            if scrubbed != nil {
+                                Button { netWorthScrub = nil } label: {
+                                    Image(systemName: "xmark.circle.fill")
+                                        .font(.caption)
+                                        .foregroundStyle(.tertiary)
+                                }
+                                .buttonStyle(.plain)
+                                .accessibilityLabel("Clear chart reading")
+                            }
+                        }
+                        Text((scrubbed?.total ?? netWorth).currency(baseCurrency))
                             .font(.system(.largeTitle, design: .rounded, weight: .bold))
                             .contentTransition(.numericText())
                     }
                     .padding(.vertical, 4)
 
                     if bands.count > 1 {
-                        NetWorthAreaChart(bands: bands, currency: baseCurrency)
-                            .padding(.vertical, 4)
+                        NetWorthAreaChart(
+                            bands: bands,
+                            currency: baseCurrency,
+                            scrubDate: $netWorthScrub,
+                            readout: scrubReadout
+                        )
+                        .padding(.vertical, 4)
                     }
 
                     // Doubles as the chart's legend — the two swatches name the bands,
@@ -192,13 +227,13 @@ struct DashboardView: View {
                         HStack(spacing: 12) {
                             BreakdownCell(
                                 title: "Cash",
-                                value: currentCash,
+                                value: scrubbed?.cash ?? currentCash,
                                 color: ChartStyle.cash,
                                 currency: baseCurrency
                             )
                             BreakdownCell(
                                 title: "Investments",
-                                value: currentPortfolioValue,
+                                value: scrubbed?.investments ?? currentPortfolioValue,
                                 color: ChartStyle.investments,
                                 currency: baseCurrency
                             )
@@ -485,6 +520,11 @@ struct NetWorthBandPoint: Identifiable {
 struct NetWorthAreaChart: View {
     let bands: [NetWorthBandPoint]
     let currency: String
+    /// Owned by the Dashboard, not this view: scrubbing re-reads the headline Net Worth
+    /// figure and the Cash / Investments cells above and below the plot, which is a
+    /// better place for the number than a tooltip drawn over the curve it came from.
+    @Binding var scrubDate: Date?
+    let readout: ChartScrubReadout?
 
     private var hasDebtBelowZero: Bool { bands.contains { $0.cash < 0 } }
 
@@ -595,6 +635,7 @@ struct NetWorthAreaChart: View {
         }
         .chartLegend(.hidden)
         .financeChartAxes(currency: currency, dateSpan: span)
+        .chartScrub(selection: $scrubDate, readout: readout)
         .adaptiveChartHeight(compact: 180, regular: 300)
     }
 }
@@ -617,36 +658,82 @@ struct NetWorthSplitChart: View {
     /// another household's screen. See `ChartStyle.netWorthColor`.
     private func color(_ slice: NetWorthSlice) -> Color { ChartStyle.netWorthColor(key: slice.key) }
 
+    /// Cumulative angle the touch landed on. `chartAngleSelection` reports a position
+    /// along the total, not a slice, so it's resolved through `ChartStyle.sliceIndex`.
+    ///
+    /// Two states, not one: Swift Charts clears its own binding the instant the finger
+    /// lifts, so `live` is what it writes and `picked` is what the view reads. That also
+    /// keeps the legend buttons working — they set `picked` directly, where the chart
+    /// can't overwrite them.
+    @State private var liveAngle: Double?
+    @State private var pickedAngle: Double?
+
+    private var selected: Int? {
+        ChartStyle.sliceIndex(atAngleValue: pickedAngle, in: breakdown.slices.map(\.value))
+    }
+
     var body: some View {
         VStack(spacing: 16) {
-            Chart(breakdown.slices) { slice in
+            Chart(Array(breakdown.slices.enumerated()), id: \.element.id) { index, slice in
                 SectorMark(
                     angle: .value("Value", slice.value),
+                    // The picked wedge grows outward — the shape itself says which one
+                    // is being read, before the label in the middle is even looked at.
                     innerRadius: .ratio(0.62),
+                    outerRadius: .ratio(selected == index ? 1.0 : 0.92),
                     angularInset: 1.5
                 )
                 .cornerRadius(3)
                 .foregroundStyle(color(slice))
+                .opacity(selected == nil || selected == index ? 1 : 0.3)
+            }
+            .chartAngleSelection(value: $liveAngle)
+            .onChange(of: liveAngle) { _, new in
+                if let new { pickedAngle = new }
             }
             .chartLegend(.hidden)
             .frame(height: 150)
+            .overlay { donutCenter }
+            .animation(.snappy(duration: 0.22), value: selected)
+            .sensoryFeedback(.selection, trigger: selected)
 
             VStack(spacing: 8) {
-                ForEach(breakdown.slices) { slice in
-                    HStack(spacing: 8) {
-                        RoundedRectangle(cornerRadius: 3, style: .continuous)
-                            .fill(color(slice))
-                            .frame(width: 11, height: 11)
-                        Text(slice.label)
-                            .font(.caption)
-                        Spacer()
-                        Text(slice.value.currencyWhole(currency))
-                            .font(.caption.monospacedDigit())
-                        Text("\(Int((slice.value / breakdown.sliceTotal * 100).rounded()))%")
-                            .font(.caption2.monospacedDigit())
-                            .foregroundStyle(.secondary)
-                            .frame(width: 36, alignment: .trailing)
+                ForEach(Array(breakdown.slices.enumerated()), id: \.element.id) { index, slice in
+                    // Tapping the legend selects the same wedge: a 30°-wide sector is a
+                    // poor touch target, and this row is the accessible way to hit it.
+                    Button {
+                        pickedAngle = selected == index ? nil : midAngleValue(of: index)
+                    } label: {
+                        HStack(spacing: 8) {
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(color(slice))
+                                .frame(width: 11, height: 11)
+                            // Each label states its own colour: the borderless button
+                            // style below tints its whole label with the accent, and an
+                            // inherited `.foregroundStyle` on the stack doesn't beat it.
+                            Text(slice.label)
+                                .font(.caption)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Text(slice.value.currencyWhole(currency))
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.primary)
+                            Text("\(Int((slice.value / breakdown.sliceTotal * 100).rounded()))%")
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .frame(width: 36, alignment: .trailing)
+                        }
+                        .contentShape(Rectangle())
+                        .opacity(selected == nil || selected == index ? 1 : 0.4)
                     }
+                    // `.borderless`, not `.plain`: inside a List row SwiftUI only
+                    // hit-tests several buttons independently for the borderless style —
+                    // with `.plain` the row swallows the tap and nothing selects. The
+                    // style tints its whole label with the accent and wins over any
+                    // `.foregroundStyle` inside it, so the tint itself is what has to be
+                    // neutralised — this is a legend, not a link.
+                    .buttonStyle(.borderless)
+                    .tint(.primary)
                 }
 
                 if breakdown.liabilities > 0 {
@@ -671,6 +758,45 @@ struct NetWorthSplitChart: View {
             }
         }
         .padding(.vertical, 4)
+    }
+}
+
+extension NetWorthSplitChart {
+    /// The hole in the middle earns its keep: net worth at rest, the picked bucket while
+    /// one is selected. Same slot, so nothing on the card moves when a wedge is tapped.
+    @ViewBuilder
+    fileprivate var donutCenter: some View {
+        VStack(spacing: 1) {
+            if let selected, breakdown.slices.indices.contains(selected) {
+                let slice = breakdown.slices[selected]
+                Text(slice.label)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(slice.value.compactCurrency(currency))
+                    .font(.headline.monospacedDigit())
+                Text("\(Int((slice.value / breakdown.sliceTotal * 100).rounded()))%")
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Net worth")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                Text(netWorth.compactCurrency(currency))
+                    .font(.headline.monospacedDigit())
+            }
+        }
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
+        .padding(.horizontal, 30)
+        .allowsHitTesting(false)
+    }
+
+    /// The cumulative angle at the middle of a slice — what the legend hands the chart to
+    /// select that wedge, since the selection is expressed as a position along the total.
+    fileprivate func midAngleValue(of index: Int) -> Double {
+        let values = breakdown.slices.map(\.value)
+        let before = values.prefix(index).reduce(0, +)
+        return before + (values[index] / 2)
     }
 }
 

--- a/ios/FinanceTracker/Views/Goals/GoalDetailView.swift
+++ b/ios/FinanceTracker/Views/Goals/GoalDetailView.swift
@@ -7,6 +7,7 @@ import Charts
 /// funded it, and recent contributions; supports editing, deleting, and adding funds.
 struct GoalDetailView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
     @Environment(\.dismiss) private var dismiss
 
     let goal: SubPortfolioResponse
@@ -25,6 +26,8 @@ struct GoalDetailView: View {
     @State private var isEditing = false
     @State private var isAddingFunds = false
     @State private var confirmingDelete = false
+    /// Where the finger is on the projection chart, or nil when nobody is scrubbing.
+    @State private var chartScrubDate: Date?
     @State private var errorMessage: String?
 
     init(goal: SubPortfolioResponse, onChanged: @escaping () async -> Void = {}) {
@@ -113,6 +116,7 @@ struct GoalDetailView: View {
             .padding(16)
         }
         .background(Color(.systemGroupedBackground))
+        .quickAddPull(quickAdd, onReload: reload)
         .navigationTitle(goalState.name)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
@@ -259,6 +263,15 @@ struct GoalDetailView: View {
                 .fixedSize(horizontal: false, vertical: true)
 
             if history.count > 1 {
+                let readout = chartScrubDate
+                    .flatMap { ChartStyle.nearest(to: $0, in: history, by: \.date) }
+                    .map { point in
+                        ChartScrubReadout(
+                            date: point.date,
+                            entries: [ChartScrubEntry(label: "Saved", value: point.value,
+                                                      color: accent, markerY: point.value)]
+                        )
+                    }
                 Chart {
                     ForEach(history) { point in
                         AreaMark(x: .value("Date", point.date), y: .value("Value", point.value))
@@ -279,7 +292,11 @@ struct GoalDetailView: View {
                     }
                 }
                 .financeChartAxes(currency: baseCurrency, showsXAxis: false)
+                .chartScrub(selection: $chartScrubDate, readout: readout)
                 .adaptiveChartHeight(compact: 160, regular: 260)
+
+                ChartScrubCaption(readout: readout, currency: baseCurrency,
+                                  selection: $chartScrubDate)
             }
         }
     }

--- a/ios/FinanceTracker/Views/Household/HouseholdMembersView.swift
+++ b/ios/FinanceTracker/Views/Household/HouseholdMembersView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// Pushed from the More tab, so it uses the caller's NavigationStack.
 struct HouseholdMembersView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
     @Environment(ViewModeStore.self) private var viewModeStore
 
     @State private var members: [HouseholdMemberUserResponse] = []
@@ -12,6 +13,9 @@ struct HouseholdMembersView: View {
     @State private var isLoading = true
     @State private var showingInvite = false
     @State private var errorMessage: String?
+    // On the screen, not the row — a dialog presented from inside a swipe-actions row
+    // is torn down with the row's collapse animation before it shows.
+    @State private var pendingRemoval: HouseholdMemberUserResponse?
 
     private var household: HouseholdResponse? { session.activeHousehold }
 
@@ -39,8 +43,31 @@ struct HouseholdMembersView: View {
                             .font(.caption.weight(.semibold))
                             .foregroundStyle(.secondary)
                     }
+                    // Per-row rather than `.onDelete` for two reasons: removing someone
+                    // from a household is irreversible from here and needs confirming,
+                    // and you can't remove yourself — the old blanket `.onDelete` still
+                    // offered the button on your own row and then silently did nothing.
+                    .swipeActions(allowsFullSwipe: false) {
+                        if member.userId != session.user?.id {
+                            Button(role: .destructive) {
+                                pendingRemoval = member
+                            } label: {
+                                Label("Remove", systemImage: "person.badge.minus")
+                            }
+                        }
+                    }
+                    // Same action on a long press: a swipe is invisible until you try
+                    // it, and unreachable from Voice Control / Switch Control.
+                    .contextMenu {
+                        if member.userId != session.user?.id {
+                            Button(role: .destructive) {
+                                pendingRemoval = member
+                            } label: {
+                                Label("Remove from Household", systemImage: "person.badge.minus")
+                            }
+                        }
+                    }
                 }
-                .onDelete { offsets in removeMembers(at: offsets) }
             }
 
             if !pendingInvites.isEmpty {
@@ -82,7 +109,24 @@ struct HouseholdMembersView: View {
         .overlay {
             if isLoading && members.isEmpty { LoadingSkeleton() }
         }
-        .refreshable { await load() }
+        .quickAddPull(quickAdd, onReload: load)
+        .confirmationDialog(
+            pendingRemoval.map { "Remove \($0.name) from this household?" } ?? "Remove this member?",
+            isPresented: .init(
+                get: { pendingRemoval != nil },
+                set: { if !$0 { pendingRemoval = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Remove", role: .destructive) {
+                if let member = pendingRemoval,
+                   let index = members.firstIndex(where: { $0.id == member.id }) {
+                    removeMembers(at: IndexSet(integer: index))
+                }
+            }
+        } message: {
+            Text("They lose access to shared accounts and goals. Re-invite them to undo it.")
+        }
         .task { await load() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },

--- a/ios/FinanceTracker/Views/More/MoreView.swift
+++ b/ios/FinanceTracker/Views/More/MoreView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 struct MoreView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
 
     #if DEBUG
     @AppStorage("api_base_url") private var apiBaseURL = ""
@@ -170,6 +171,7 @@ struct MoreView: View {
                 }
             }
             .navigationTitle("More")
+            .quickAddPull(quickAdd, onReload: {})
             .confirmationDialog("Log out of Waypoint?", isPresented: $showingLogoutConfirm, titleVisibility: .visible) {
                 Button("Log Out", role: .destructive) {
                     session.logout()

--- a/ios/FinanceTracker/Views/Portfolio/PortfolioView.swift
+++ b/ios/FinanceTracker/Views/Portfolio/PortfolioView.swift
@@ -202,6 +202,22 @@ struct PortfolioView: View {
                                     .tint(.blue)
                                 }
                             }
+                            // Same actions on a long press: a swipe is invisible until
+                            // you try it, and unreachable from Voice Control / Switch
+                            // Control. Record Price is here too — tapping the row is the
+                            // only other way to reach it, and only for manual assets.
+                            .contextMenu {
+                                if let asset, !asset.isPseudoAsset {
+                                    if asset.isManualPriced {
+                                        Button { pricingAsset = asset } label: {
+                                            Label("Record Price", systemImage: "square.and.pencil")
+                                        }
+                                    }
+                                    Button { editingAsset = asset } label: {
+                                        Label("Edit Asset", systemImage: "pencil")
+                                    }
+                                }
+                            }
                         }
                     } header: {
                         HStack {
@@ -452,23 +468,42 @@ struct GrowthChart: View {
     var compactHeight: CGFloat = 160
     var regularHeight: CGFloat = 280
 
+    @State private var scrubDate: Date?
+
     private var span: TimeInterval? {
         guard let first = curve.first?.date, let last = curve.last?.date else { return nil }
         return last.timeIntervalSince(first)
     }
 
+    private var readout: ChartScrubReadout? {
+        guard let scrubDate,
+              let point = ChartStyle.nearest(to: scrubDate, in: curve, by: \.date)
+        else { return nil }
+        return ChartScrubReadout(
+            date: point.date,
+            entries: [
+                ChartScrubEntry(label: "Value", value: point.value, color: accent, markerY: point.value)
+            ]
+        )
+    }
+
     var body: some View {
-        Chart(curve) { point in
-            AreaMark(x: .value("Date", point.date), y: .value("Value", point.value))
-                .foregroundStyle(ChartStyle.accentFill(accent))
-                .interpolationMethod(.monotone)
-            LineMark(x: .value("Date", point.date), y: .value("Value", point.value))
-                .foregroundStyle(accent)
-                .lineStyle(StrokeStyle(lineWidth: ChartStyle.lineWidth, lineCap: .round, lineJoin: .round))
-                .interpolationMethod(.monotone)
+        VStack(alignment: .leading, spacing: 6) {
+            Chart(curve) { point in
+                AreaMark(x: .value("Date", point.date), y: .value("Value", point.value))
+                    .foregroundStyle(ChartStyle.accentFill(accent))
+                    .interpolationMethod(.monotone)
+                LineMark(x: .value("Date", point.date), y: .value("Value", point.value))
+                    .foregroundStyle(accent)
+                    .lineStyle(StrokeStyle(lineWidth: ChartStyle.lineWidth, lineCap: .round, lineJoin: .round))
+                    .interpolationMethod(.monotone)
+            }
+            .financeChartAxes(currency: baseCurrency, dateSpan: span)
+            .chartScrub(selection: $scrubDate, readout: readout)
+            .adaptiveChartHeight(compact: compactHeight, regular: regularHeight)
+
+            ChartScrubCaption(readout: readout, currency: baseCurrency, selection: $scrubDate)
         }
-        .financeChartAxes(currency: baseCurrency, dateSpan: span)
-        .adaptiveChartHeight(compact: compactHeight, regular: regularHeight)
     }
 }
 
@@ -509,42 +544,104 @@ struct AllocationCard: View {
 
     private func color(_ index: Int) -> Color { Self.palette[index % Self.palette.count] }
 
+    /// Cumulative angle the touch landed on; resolved to a slice by `ChartStyle.sliceIndex`.
+    ///
+    /// Two states, not one: Swift Charts clears its own binding the instant the finger
+    /// lifts, so `live` is what it writes and `picked` is what the view reads — which
+    /// also keeps the legend buttons working, since they set `picked` directly.
+    @State private var liveAngle: Double?
+    @State private var pickedAngle: Double?
+
+    private var selected: Int? {
+        ChartStyle.sliceIndex(atAngleValue: pickedAngle, in: slices.map(\.value))
+    }
+
+    /// The cumulative angle at the middle of a slice — what a legend tap hands the chart,
+    /// since the selection is a position along the total rather than an identity.
+    private func midAngleValue(of index: Int) -> Double {
+        let values = slices.map(\.value)
+        let before = values.prefix(index).reduce(0, +)
+        return before + (values[index] / 2)
+    }
+
     var body: some View {
         VStack(spacing: 16) {
             Chart(Array(slices.enumerated()), id: \.element.id) { index, slice in
                 SectorMark(
                     angle: .value("Value", slice.value),
+                    // The picked wedge grows outward, so the shape says which one is
+                    // being read before the label in the middle is looked at.
                     innerRadius: .ratio(0.62),
+                    outerRadius: .ratio(selected == index ? 1.0 : 0.92),
                     angularInset: 1.5
                 )
                 .cornerRadius(3)
                 .foregroundStyle(color(index))
+                .opacity(selected == nil || selected == index ? 1 : 0.3)
+            }
+            .chartAngleSelection(value: $liveAngle)
+            .onChange(of: liveAngle) { _, new in
+                if let new { pickedAngle = new }
             }
             .chartLegend(.hidden)
             .frame(height: 150)
             .overlay {
                 VStack(spacing: 0) {
-                    Text("\(holdingsCount)")
-                        .font(.title3.monospacedDigit().weight(.bold))
-                    Text(holdingsCount == 1 ? "holding" : "holdings")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
+                    if let selected, slices.indices.contains(selected) {
+                        Text(slices[selected].label)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text("\(Int(slices[selected].pct.rounded()))%")
+                            .font(.title3.monospacedDigit().weight(.bold))
+                    } else {
+                        Text("\(holdingsCount)")
+                            .font(.title3.monospacedDigit().weight(.bold))
+                        Text(holdingsCount == 1 ? "holding" : "holdings")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
                 }
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+                .padding(.horizontal, 30)
+                .allowsHitTesting(false)
             }
+            .animation(.snappy(duration: 0.22), value: selected)
+            .sensoryFeedback(.selection, trigger: selected)
 
             VStack(spacing: 8) {
                 ForEach(Array(slices.enumerated()), id: \.element.id) { index, slice in
-                    HStack(spacing: 8) {
-                        RoundedRectangle(cornerRadius: 3, style: .continuous)
-                            .fill(color(index))
-                            .frame(width: 11, height: 11)
-                        Text(slice.label)
-                            .font(.caption)
-                        Spacer()
-                        Text("\(Int(slice.pct.rounded()))%")
-                            .font(.caption.monospacedDigit())
-                            .foregroundStyle(.secondary)
+                    // Tapping the legend picks the same wedge — a thin sector is a poor
+                    // touch target, and this row is the accessible way to hit it.
+                    Button {
+                        pickedAngle = selected == index ? nil : midAngleValue(of: index)
+                    } label: {
+                        HStack(spacing: 8) {
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(color(index))
+                                .frame(width: 11, height: 11)
+                            // Each label states its own colour: the borderless button
+                            // style below tints its whole label with the accent, and an
+                            // inherited `.foregroundStyle` on the stack doesn't beat it.
+                            Text(slice.label)
+                                .font(.caption)
+                                .foregroundStyle(.primary)
+                            Spacer()
+                            Text("\(Int(slice.pct.rounded()))%")
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+                        .contentShape(Rectangle())
+                        .opacity(selected == nil || selected == index ? 1 : 0.4)
                     }
+                    // `.borderless`, not `.plain`: inside a List row SwiftUI only
+                    // hit-tests several buttons independently for the borderless style —
+                    // with `.plain` the row swallows the tap and nothing selects. The
+                    // style tints its whole label with the accent and wins over any
+                    // `.foregroundStyle` inside it, so the tint itself is what has to be
+                    // neutralised — this is a legend, not a link.
+                    .buttonStyle(.borderless)
+                    .tint(.primary)
                 }
             }
 

--- a/ios/FinanceTracker/Views/Portfolio/TradesListView.swift
+++ b/ios/FinanceTracker/Views/Portfolio/TradesListView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Individual buy/sell trades, newest first, grouped by month. Tap a trade to edit it
-/// (PUT /portfolio/trades/{id}); swipe to delete. Reached from the Portfolio tab.
+/// (PUT /portfolio/trades/{id}); swipe to delete (confirmed first). Reached from the Portfolio tab.
 /// Cash deposit/withdraw legs (the CASH pseudo-asset) are hidden — this is real trades.
 struct TradesListView: View {
     @Environment(SessionStore.self) private var session
@@ -15,6 +15,9 @@ struct TradesListView: View {
     @State private var isLoading = true
     @State private var editingTrade: TradeResponse?
     @State private var errorMessage: String?
+    // Confirmation state on the screen, not the row — a dialog presented from inside a
+    // swipe-actions row is torn down with the row's collapse animation before it shows.
+    @State private var pendingDelete: TradeResponse?
 
     private func asset(_ id: String?) -> AssetResponse? {
         id.flatMap { aid in assets.first { $0.id == aid } }
@@ -61,8 +64,27 @@ struct TradesListView: View {
                             )
                         }
                         .buttonStyle(.plain)
+                        // Not `.onDelete`: deleting a trade replays every portfolio
+                        // snapshot from its date forward, with no undo — too much to
+                        // hang off an accidental full swipe.
+                        .swipeActions(allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                pendingDelete = trade
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        // Same actions on a long press: a swipe is invisible until you
+                        // try it, and unreachable from Voice Control / Switch Control.
+                        .contextMenu {
+                            Button { editingTrade = trade } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+                            Button(role: .destructive) { pendingDelete = trade } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                     }
-                    .onDelete { offsets in delete(group.trades, at: offsets) }
                 }
             }
         }
@@ -93,6 +115,22 @@ struct TradesListView: View {
             }
         }
         .quickAddPull(quickAdd, onReload: load)
+        .confirmationDialog(
+            "Delete this trade?",
+            isPresented: .init(
+                get: { pendingDelete != nil },
+                set: { if !$0 { pendingDelete = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete", role: .destructive) {
+                if let trade = pendingDelete {
+                    delete([trade], at: IndexSet(integer: 0))
+                }
+            }
+        } message: {
+            Text("Holdings and portfolio history are recalculated from this trade's date. This can't be undone.")
+        }
         .task { await load() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },

--- a/ios/FinanceTracker/Views/Recurring/RecurringView.swift
+++ b/ios/FinanceTracker/Views/Recurring/RecurringView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// about seeing what's committed and correcting it, not about data entry.
 struct RecurringView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
     @Environment(ViewModeStore.self) private var viewModeStore
 
     @State private var rules: [RecurringTransactionResponse] = []
@@ -157,7 +158,7 @@ struct RecurringView: View {
         .overlay {
             if isLoading && rules.isEmpty { LoadingSkeleton() }
         }
-        .refreshable { await load() }
+        .quickAddPull(quickAdd, onReload: load)
         .task { await load() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },
@@ -329,6 +330,21 @@ struct RecurringRuleRow: View {
         // from the parent once `onRequestDelete` fires) is the only path to
         // an actual delete.
         .swipeActions(allowsFullSwipe: false) {
+            Button(role: .destructive, action: onRequestDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+            .disabled(isDeleting)
+        }
+        // Both swipes again on a long press: a swipe is invisible until you try it, and
+        // unreachable from Voice Control / Switch Control. The leading Pause/Resume is
+        // especially easy to miss — nothing on the row says a left edge exists.
+        .contextMenu {
+            Button {
+                Task { await onToggle() }
+            } label: {
+                Label(rule.isActive ? "Pause" : "Resume",
+                      systemImage: rule.isActive ? "pause" : "play")
+            }
             Button(role: .destructive, action: onRequestDelete) {
                 Label("Delete", systemImage: "trash")
             }

--- a/ios/FinanceTracker/Views/Reports/ReportsView.swift
+++ b/ios/FinanceTracker/Views/Reports/ReportsView.swift
@@ -7,6 +7,7 @@ import UIKit
 /// Pushed from the More tab, so it uses the caller's NavigationStack.
 struct ReportsView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
 
     @State private var report: HouseholdReportResponse?
     @State private var isLoading = true
@@ -129,7 +130,7 @@ struct ReportsView: View {
                 LoadingSkeleton(showsHeader: true)
             }
         }
-        .refreshable { await load() }
+        .quickAddPull(quickAdd, onReload: load)
         .task { await load() }
         .sheet(item: $exportFile) { file in
             ShareSheet(items: [file.url])

--- a/ios/FinanceTracker/Views/Transactions/CategoriesView.swift
+++ b/ios/FinanceTracker/Views/Transactions/CategoriesView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 /// Reached from the More tab; also surfaced inline from the New Transaction sheet.
 struct CategoriesView: View {
     @Environment(SessionStore.self) private var session
+    @Environment(QuickAddStore.self) private var quickAdd
 
     @State private var categories: [CategoryResponse] = []
     @State private var isLoading = true
@@ -37,8 +38,34 @@ struct CategoriesView: View {
                                     .foregroundStyle(.tertiary)
                             }
                         }
+                        // Reveal-then-tap rather than `.onDelete`'s full swipe. A
+                        // category still used by a transaction is refused server-side,
+                        // so the cost of a slip is low — but low enough to be worth one
+                        // deliberate tap, not low enough to commit on a flick.
+                        .swipeActions(allowsFullSwipe: false) {
+                            Button(role: .destructive) {
+                                if let index = items.firstIndex(where: { $0.id == category.id }) {
+                                    delete(items, at: IndexSet(integer: index))
+                                }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
+                        // Same actions on a long press: a swipe is invisible until you
+                        // try it, and unreachable from Voice Control / Switch Control.
+                        .contextMenu {
+                            Button { editing = category } label: {
+                                Label("Edit", systemImage: "pencil")
+                            }
+                            Button(role: .destructive) {
+                                if let index = items.firstIndex(where: { $0.id == category.id }) {
+                                    delete(items, at: IndexSet(integer: index))
+                                }
+                            } label: {
+                                Label("Delete", systemImage: "trash")
+                            }
+                        }
                     }
-                    .onDelete { offsets in delete(items, at: offsets) }
                 }
             }
         }
@@ -78,7 +105,7 @@ struct CategoriesView: View {
                 }
             }
         }
-        .refreshable { await load() }
+        .quickAddPull(quickAdd, onReload: load)
         .task { await load() }
         .alert("Error", isPresented: .init(
             get: { errorMessage != nil },

--- a/ios/FinanceTracker/Views/Transactions/TransactionsView.swift
+++ b/ios/FinanceTracker/Views/Transactions/TransactionsView.swift
@@ -14,6 +14,9 @@ struct TransactionsView: View {
     @State private var showingAddSheet = false
     @State private var showingTransferSheet = false
     @State private var editingTransaction: TransactionResponse?
+    // Held on the screen rather than the row — a confirmation presented from inside
+    // a swipe-actions row is torn down with the row's collapse animation before it shows.
+    @State private var pendingDelete: TransactionResponse?
     @State private var errorMessage: String?
     @State private var lastLoadedAt: Date?
     @State private var hiddenCategoryIds: Set<String> = []
@@ -204,22 +207,7 @@ struct TransactionsView: View {
                 ForEach(groups) { group in
                     Section {
                         ForEach(group.items) { txn in
-                            let row = TransactionRow(
-                                transaction: txn,
-                                categoryName: categoriesById[txn.categoryId]?.name,
-                                accountName: accountsById[txn.accountId]?.name,
-                                baseCurrency: baseCurrency
-                            )
-                            // Transfers are two linked legs; edit them where they're created, not here.
-                            if txn.transferId == nil {
-                                Button { editingTransaction = txn } label: { row }
-                                    .buttonStyle(.plain)
-                            } else {
-                                row
-                            }
-                        }
-                        .onDelete { offsets in
-                            delete(group.items, at: offsets)
+                            transactionRow(txn)
                         }
                     } header: {
                         HistorySectionHeader(
@@ -292,6 +280,22 @@ struct TransactionsView: View {
                 }
             }
             .quickAddPull(quickAdd, onReload: load)
+            .confirmationDialog(
+                "Delete this transaction?",
+                isPresented: .init(
+                    get: { pendingDelete != nil },
+                    set: { if !$0 { pendingDelete = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button("Delete", role: .destructive) {
+                    if let txn = pendingDelete {
+                        delete([txn], at: IndexSet(integer: 0))
+                    }
+                }
+            } message: {
+                Text("The account balance it moved is recalculated. This can't be undone.")
+            }
             .task { await loadIfNeeded() }
             // Restore the saved Top-Categories filter/period on appear and whenever the active
             // household changes, so the user doesn't re-hide the same categories every visit.
@@ -316,6 +320,50 @@ struct TransactionsView: View {
                 Button("OK", role: .cancel) {}
             } message: {
                 Text(errorMessage ?? "")
+            }
+        }
+    }
+
+    /// One activity row. Extracted from `body` so the list stays inside the
+    /// type-checker's budget, not for reuse.
+    @ViewBuilder
+    private func transactionRow(_ txn: TransactionResponse) -> some View {
+        let row = TransactionRow(
+            transaction: txn,
+            categoryName: categoriesById[txn.categoryId]?.name,
+            accountName: accountsById[txn.accountId]?.name,
+            baseCurrency: baseCurrency
+        )
+        // Transfers are two linked legs; edit them where they're created, not here.
+        Group {
+            if txn.transferId == nil {
+                Button { editingTransaction = txn } label: { row }
+                    .buttonStyle(.plain)
+            } else {
+                row
+            }
+        }
+        // `allowsFullSwipe: false` + a confirmation instead of the plain `.onDelete`:
+        // deleting a transaction rewrites account balances server-side and there is no
+        // undo, so a fast swipe must reveal the button, not commit the delete.
+        .swipeActions(allowsFullSwipe: false) {
+            Button(role: .destructive) {
+                pendingDelete = txn
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+        // The same actions on a long press. A swipe is invisible until you try it and
+        // is out of reach of Voice Control and Switch Control; the menu is the
+        // discoverable, nameable half of the same pair.
+        .contextMenu {
+            if txn.transferId == nil {
+                Button { editingTransaction = txn } label: {
+                    Label("Edit", systemImage: "pencil")
+                }
+            }
+            Button(role: .destructive) { pendingDelete = txn } label: {
+                Label("Delete", systemImage: "trash")
             }
         }
     }
@@ -725,6 +773,17 @@ struct CategoryBreakdownCard: View {
 
     private var topMax: Double { max(breakdown.top.map(\.amount).max() ?? 1, 1) }
 
+    /// Cumulative angle the touch landed on; resolved to a slice by `ChartStyle.sliceIndex`.
+    ///
+    /// Two states, not one: Swift Charts clears its own binding the instant the finger
+    /// lifts, so `live` is what it writes and `picked` is what the view reads.
+    @State private var liveAngle: Double?
+    @State private var pickedAngle: Double?
+
+    private var selected: Int? {
+        ChartStyle.sliceIndex(atAngleValue: pickedAngle, in: pieSlices.map(\.amount))
+    }
+
     /// Bound non-optional dates for the two DatePickers; picking a date is what turns the
     /// corresponding open-ended bound into a real one.
     private var startBinding: Binding<Date> {
@@ -785,17 +844,49 @@ struct CategoryBreakdownCard: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
             } else {
-                Chart(pieSlices) { slice in
+                Chart(Array(pieSlices.enumerated()), id: \.element.id) { index, slice in
                     SectorMark(
                         angle: .value("Amount", slice.amount),
+                        // The picked wedge grows outward, so the shape says which one is
+                        // being read before the label in the middle is looked at.
                         innerRadius: .ratio(0.55),
+                        outerRadius: .ratio(selected == index ? 1.0 : 0.92),
                         angularInset: 1.5
                     )
                     .cornerRadius(3)
                     .foregroundStyle(color(slice.id))
+                    .opacity(selected == nil || selected == index ? 1 : 0.3)
+                }
+                .chartAngleSelection(value: $liveAngle)
+                .onChange(of: liveAngle) { _, new in
+                    if let new { pickedAngle = new }
                 }
                 .chartLegend(.hidden)
                 .frame(height: 140)
+                .overlay {
+                    VStack(spacing: 1) {
+                        if let selected, pieSlices.indices.contains(selected) {
+                            let slice = pieSlices[selected]
+                            Text(slice.name)
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(slice.amount.compactCurrency(baseCurrency))
+                                .font(.headline.monospacedDigit())
+                        } else {
+                            Text("Spent")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                            Text(breakdown.total.compactCurrency(baseCurrency))
+                                .font(.headline.monospacedDigit())
+                        }
+                    }
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.7)
+                    .padding(.horizontal, 24)
+                    .allowsHitTesting(false)
+                }
+                .animation(.snappy(duration: 0.22), value: selected)
+                .sensoryFeedback(.selection, trigger: selected)
 
                 VStack(spacing: 10) {
                     ForEach(breakdown.top) { cat in


### PR DESCRIPTION
A pass over every gesture in the iOS app against Apple's fluid-interface principles, plus the two interactions that were missing entirely.

## Charts — all seven are now readable, not just viewable

**Time-series** (Dashboard net worth, `GrowthChart`, goal projection, account balance) scrub with a drag via a new `.chartScrub` in `ChartStyle`: a rule, a dot on the line, a `.selection` haptic per datum, and the reading in a caption beside the plot rather than a tooltip drawn over the data being asked about. The Dashboard goes further and rewrites its own headline figure, date label and both breakdown cells from the scrub instead of adding a caption.

**Donuts** (net worth split, allocation, top categories) select a wedge via `.chartAngleSelection` + `ChartStyle.sliceIndex`, which resolves the *cumulative* angle the API reports back to a slice. The picked wedge grows outward, the rest dim, the donut's centre reads it out, and the legend rows pick the same wedge — a 2%-wide sector is a poor touch target and the legend is the accessible way in.

## Pull-to-Quick-Add

- **Now on every browse screen**, and `.refreshable` is gone from the app. The same downward pull had to mean the same thing everywhere; the old split by "main tab vs. More tab" was a distinction only the code could see. Modal sheets and edit forms deliberately keep no pull.
- **The release *direction* decides, not its speed.** The old rule cancelled on any release above 1200 pt/s, so a confident fast pull was silently swallowed *after* the badge had already promised "Release for Quick Add" and the haptic had fired. Only a sharp flick back up reads as taking it back now. The anti-accident protection this was doing is already handled by the `dragging` gate, which momentum overscroll can never satisfy.
- Disarming gets its own softer haptic, the badge springs back instead of vanishing mid-air, `dragging` is cleared when the sheet opens (a cancelled drag never reaches `onEnded` and left it stuck true), and Reduce Motion drops the icon spin.

## Row actions

- **Every swipe action is mirrored by a `.contextMenu`.** A swipe is invisible until you try it and is out of reach of Voice Control and Switch Control, so it can no longer be the only path to an action.
- **Irreversible deletes confirm.** Transaction, trade, budget, category and member deletes move off `.onDelete` to `allowsFullSwipe: false` + a confirmation dialog — a full swipe must reveal the button, not commit. Deleting a transaction rewrites account balances; deleting a trade replays every snapshot from its date. `RecurringView` had already solved this and documented why; the rest now match. Cancelling an invite stays a plain swipe on purpose (re-inviting undoes it).
- Members also stop offering a Remove button on your own row that then silently did nothing.
- The Budgets row was an `.onTapGesture` — no press highlight, no button trait, inert-looking until the sheet appeared. It's a `Button` like every other row now.
- `LoadingSkeleton`'s endless shimmer respects Reduce Motion.

## Two SwiftUI findings reviewers should know

Both are written up in `ios/AGENTS.md`, because both cost real time to find:

1. **Swift Charts clears its own selection the instant the finger lifts.** A reading that vanishes on release is useless on a money chart — you look a date up in order to *read* it. Each chart keeps a live binding for what Charts writes and a sticky one for what the view renders, plus an explicit clear (an ✕ in the caption / next to the Dashboard date).
2. **Inside a `List` row, `.buttonStyle(.plain)` swallows taps when the row holds several buttons** — only `.borderless` hit-tests them independently (A/B'd on device). Its accent tint then beats any `.foregroundStyle` inside the label, so the legends need `.tint(.primary)` to stay legible.

## Still outstanding

`ios/AGENTS.md` now records the **interactive-dismissal gap**: no form uses `interactiveDismissDisabled`, so dragging a sheet down discards a half-filled trade/transaction/account form with no prompt. Fixing it needs per-form dirty tracking plus a "Discard changes?" dialog across all seven create/edit sheets, and should be one uniform pass rather than sheet-by-sheet.

One behaviour change worth a second opinion: dropping `.refreshable` leaves **no manual refresh anywhere**. Screens refetch on `.task` and on `QuickAddStore.reloadToken`, which is what the seven main screens already did — but on Members & Invites, someone else accepting an invite now only appears after navigating away and back. Happy to add a toolbar Refresh there if you'd rather.

## Verification

Build clean, **166 tests pass**. Exercised on the iPhone 17 Pro simulator: scrub rewriting the Dashboard headline to a past date and the ✕ restoring today; wedge selection showing Property $550K / 98%; the Edit/Delete context menu; a fast full swipe revealing Delete rather than committing, and the confirmation appearing without the row collapsing out from under it; the pull opening Quick Add from the More tab; and both pull branches (fast pull-and-release commits, flick-back-up cancels).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
