### PR TITLE
Card category in Quick Add, and stop card spending vanishing into no category

### DIFF
--- a/android/app/src/main/java/com/ivanlee/financetracker/data/CardLoader.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/data/CardLoader.kt
@@ -1,0 +1,36 @@
+package com.ivanlee.financetracker.data
+
+import com.ivanlee.financetracker.data.model.CardLimitStatusRow
+import com.ivanlee.financetracker.data.model.CardResponse
+import com.ivanlee.financetracker.data.model.CardStatusResponse
+import com.ivanlee.financetracker.data.net.Api
+import com.ivanlee.financetracker.logic.Cards
+
+/**
+ * The card behind an account, with this cycle's headroom — or null, which is the
+ * ordinary answer for an account that is not a card rather than an error.
+ *
+ * Shared by the transaction form and Quick Add so the two cannot drift into
+ * saying different things about the same card. It lives here rather than in
+ * `logic/` because it makes network calls, and `logic/` is the pure,
+ * JVM-testable half.
+ */
+data class LoadedCard(
+    val card: CardResponse,
+    val headroom: Map<String, CardLimitStatusRow>,
+)
+
+suspend fun loadCardForAccount(householdId: String, accountId: String): LoadedCard? {
+    val card = runCatching {
+        Api.get<List<CardResponse>>("/cards/household/$householdId")
+            .firstOrNull { it.financialAccountId == accountId }
+    }.getOrNull() ?: return null
+
+    // A missing meter makes the picker plainer, never the form unusable, so the
+    // status is allowed to fail on its own.
+    val headroom = runCatching {
+        Cards.headroomByCategory(card, Api.get<CardStatusResponse>("/cards/${card.id}/status"))
+    }.getOrDefault(emptyMap())
+
+    return LoadedCard(card, headroom)
+}

--- a/android/app/src/main/java/com/ivanlee/financetracker/logic/Cards.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/logic/Cards.kt
@@ -93,6 +93,16 @@ object Cards {
     }
 
     /**
+     * A limit with no categories pointing at it measures nothing.
+     *
+     * A setup mistake rather than a state worth rendering as a meter: the user
+     * made a cap and never said what counts towards it. Left alone it draws a
+     * perfectly plausible "0 of $1,000" bar and reads as "nothing spent yet",
+     * which is the one thing it must not be mistaken for.
+     */
+    fun measuresNothing(row: CardLimitStatusRow): Boolean = row.categoryNames.isEmpty()
+
+    /**
      * The limits worth interrupting someone about — burst, or on pace to be.
      *
      * Used for the dashboard's exception row, which shows nothing at all when

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/more/CardsScreen.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/more/CardsScreen.kt
@@ -283,6 +283,15 @@ fun CardLimitMeter(row: CardLimitStatusRow, currency: String) {
             )
         }
 
+        if (Cards.measuresNothing(row)) {
+            Text(
+                "No categories point at this limit yet, so it isn't measuring anything.",
+                style = MaterialTheme.typography.bodySmall,
+                color = warningColor(),
+                modifier = Modifier.padding(top = 2.dp),
+            )
+        }
+
         if (tone == Cards.Tone.AT_RISK) {
             Text(
                 if (row.direction == LimitDirection.FLOOR) {

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.ivanlee.financetracker.data.loadCardForAccount
 import com.ivanlee.financetracker.logic.currencyWhole
 import com.ivanlee.financetracker.logic.Cards
 import com.ivanlee.financetracker.data.model.CardLimitStatusRow
@@ -118,18 +119,10 @@ fun QuickAddSheet(
         val householdId = sessionVm.activeHousehold?.id
         val account = accountId
         cardCategoryId = null
-        if (householdId == null || account == null) {
-            card = null; cardHeadroom = emptyMap(); return@LaunchedEffect
-        }
-        val match = runCatching {
-            Api.get<List<CardResponse>>("/cards/household/$householdId")
-                .firstOrNull { it.financialAccountId == account }
-        }.getOrNull()
-        card = match
-        // A missing meter makes the picker plainer, never the sheet unusable.
-        cardHeadroom = if (match == null) emptyMap() else runCatching {
-            Cards.headroomByCategory(match, Api.get<CardStatusResponse>("/cards/${match.id}/status"))
-        }.getOrDefault(emptyMap())
+        val loaded = if (householdId == null || account == null) null
+                     else loadCardForAccount(householdId, account)
+        card = loaded?.card
+        cardHeadroom = loaded?.headroom ?: emptyMap()
     }
     var fromAccountId by remember { mutableStateOf<String?>(null) }
     var toAccountId by remember { mutableStateOf<String?>(null) }

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
@@ -30,6 +30,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import com.ivanlee.financetracker.logic.currencyWhole
+import com.ivanlee.financetracker.logic.Cards
+import com.ivanlee.financetracker.data.model.CardLimitStatusRow
+import com.ivanlee.financetracker.data.model.CardStatusResponse
+import com.ivanlee.financetracker.data.model.CardResponse
 import com.ivanlee.financetracker.logic.selectableAccounts
 import com.ivanlee.financetracker.data.model.AccountResponse
 import com.ivanlee.financetracker.data.model.AssetResponse
@@ -101,6 +106,31 @@ fun QuickAddSheet(
 
     var accountId by remember { mutableStateOf<String?>(null) }
     var categoryId by remember { mutableStateOf<String?>(null) }
+    // The card behind the selected account, if it is one. Fetched on demand —
+    // most accounts are not cards, and Quick Add is meant to be fast.
+    var card by remember { mutableStateOf<CardResponse?>(null) }
+    var cardHeadroom by remember { mutableStateOf<Map<String, CardLimitStatusRow>>(emptyMap()) }
+    var cardCategoryId by remember { mutableStateOf<String?>(null) }
+
+    // Reloads whenever the account changes. A pick from the old card is
+    // meaningless on a new one, so it is cleared here as well as server-side.
+    LaunchedEffect(accountId, sessionVm.activeHousehold?.id) {
+        val householdId = sessionVm.activeHousehold?.id
+        val account = accountId
+        cardCategoryId = null
+        if (householdId == null || account == null) {
+            card = null; cardHeadroom = emptyMap(); return@LaunchedEffect
+        }
+        val match = runCatching {
+            Api.get<List<CardResponse>>("/cards/household/$householdId")
+                .firstOrNull { it.financialAccountId == account }
+        }.getOrNull()
+        card = match
+        // A missing meter makes the picker plainer, never the sheet unusable.
+        cardHeadroom = if (match == null) emptyMap() else runCatching {
+            Cards.headroomByCategory(match, Api.get<CardStatusResponse>("/cards/${match.id}/status"))
+        }.getOrDefault(emptyMap())
+    }
     var fromAccountId by remember { mutableStateOf<String?>(null) }
     var toAccountId by remember { mutableStateOf<String?>(null) }
 
@@ -206,6 +236,7 @@ fun QuickAddSheet(
                             description = description.ifBlank { null },
                             accountId = accountId!!,
                             categoryId = categoryId!!,
+                            cardCategoryId = cardCategoryId,
                         ),
                     )
 
@@ -319,6 +350,21 @@ fun QuickAddSheet(
                 TextButton(onClick = { showNewCategory = true }) {
                     Icon(Icons.Filled.AddCircleOutline, contentDescription = null)
                     Text("  New Category")
+                }
+                // Only when the account is a card. Quick Add is a deliberately
+                // reduced surface — it leaves out the split and the merchant
+                // code — but this one earns its row: it carries the headroom,
+                // and logging card spend is exactly when that number can change
+                // a decision.
+                card?.let { activeCard ->
+                    val currency = activeCard.currency ?: baseCurrency
+                    DropdownField(
+                        label = "Card category",
+                        selected = activeCard.categories.firstOrNull { it.id == cardCategoryId },
+                        options = activeCard.categories,
+                        optionLabel = { Cards.categoryLabel(it, cardHeadroom) { v -> v.currencyWhole(currency) } },
+                        onSelect = { cardCategoryId = it.id },
+                    )
                 }
             }
 

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/transactions/TransactionFormScreen.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/transactions/TransactionFormScreen.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import com.ivanlee.financetracker.data.loadCardForAccount
 import com.ivanlee.financetracker.logic.selectableAccounts
 import com.ivanlee.financetracker.data.model.AccountResponse
 import com.ivanlee.financetracker.data.model.CategoryResponse
@@ -378,33 +379,19 @@ fun TransactionFormScreen(
         }
     }
 
-    // Reloads whenever the account changes, including the first time one is picked.
-    // A pick from the old card is meaningless on a new one, so it is cleared here as
-    // well as server-side.
+    // Reloads whenever the account changes, including the first time one is
+    // picked. A pick from the old card is meaningless on a new one, so it is
+    // cleared here as well as server-side.
     LaunchedEffect(accountId, sessionVm.activeHousehold?.id) {
         val householdId = sessionVm.activeHousehold?.id
         val account = accountId
-        if (householdId == null || account == null) {
-            card = null
-            cardHeadroom = emptyMap()
-            return@LaunchedEffect
+        val loaded = if (householdId == null || account == null) null
+                     else loadCardForAccount(householdId, account)
+        if (loaded?.card?.id != card?.id) {
+            cardCategoryId = existing?.cardCategoryId.takeIf { existing?.accountId == account }
         }
-        val match = runCatching {
-            Api.get<List<CardResponse>>("/cards/household/$householdId")
-                .firstOrNull { it.financialAccountId == account }
-        }.getOrNull()
-        if (match == null) {
-            card = null
-            cardHeadroom = emptyMap()
-            cardCategoryId = null
-            return@LaunchedEffect
-        }
-        if (match.id != card?.id) cardCategoryId = existing?.cardCategoryId.takeIf { existing?.accountId == account }
-        card = match
-        // A missing meter makes the picker plainer, not the form unusable.
-        cardHeadroom = runCatching {
-            Cards.headroomByCategory(match, Api.get<CardStatusResponse>("/cards/${match.id}/status"))
-        }.getOrDefault(emptyMap())
+        card = loaded?.card
+        cardHeadroom = loaded?.headroom ?: emptyMap()
     }
 
     if (showCardCategoryPicker) {

--- a/backend/alembic/versions/beea2ea972a2_every_card_needs_a_default_category.py
+++ b/backend/alembic/versions/beea2ea972a2_every_card_needs_a_default_category.py
@@ -1,0 +1,67 @@
+"""every card needs a default category
+
+Revision ID: beea2ea972a2
+Revises: 99b6418c7347
+Create Date: 2026-08-28 17:02:32.416526
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'beea2ea972a2'
+down_revision: Union[str, Sequence[str], None] = '99b6418c7347'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """
+    Give every existing card a default category, and promote one where the
+    categories exist but none is marked default.
+
+    Untagged spend is resolved *to* the default when a cycle is totalled, so a
+    card without one has nowhere to put it: the spend is computed and then
+    dropped. Setting up a card, adding a cap and spending on it showed a meter
+    reading zero — the opposite of what the feature is for.
+
+    `create_card` now seeds this, so it is only the cards already out there that
+    need it.
+    """
+    # 1. Cards with no categories at all.
+    op.execute(
+        """
+        INSERT INTO finance_tracker.card_categories (id, card_id, name, is_default, sort_order)
+        SELECT gen_random_uuid(), c.id, 'Everything else', true, 0
+          FROM finance_tracker.cards c
+         WHERE NOT EXISTS (
+               SELECT 1 FROM finance_tracker.card_categories cc WHERE cc.card_id = c.id
+           )
+        """
+    )
+    # 2. Cards that have categories but no default — promote the lowest-sorted,
+    #    which is the one a client lists first.
+    op.execute(
+        """
+        UPDATE finance_tracker.card_categories
+           SET is_default = true
+         WHERE id IN (
+               SELECT DISTINCT ON (cc.card_id) cc.id
+                 FROM finance_tracker.card_categories cc
+                WHERE NOT EXISTS (
+                      SELECT 1 FROM finance_tracker.card_categories d
+                       WHERE d.card_id = cc.card_id AND d.is_default
+                  )
+             ORDER BY cc.card_id, cc.sort_order, cc.name
+           )
+        """
+    )
+
+
+def downgrade() -> None:
+    # Deliberately not reversed. Removing a card's only category would restore
+    # the hole this closes, and the seeded row may by then hold transactions.
+    pass

--- a/backend/src/routers/cards.py
+++ b/backend/src/routers/cards.py
@@ -22,6 +22,9 @@ from src.services import card_service
 
 router = APIRouter(prefix="/cards", tags=["Cards"])
 
+# Where a card's untagged spend lands until the user says otherwise.
+DEFAULT_CARD_CATEGORY_NAME = "Everything else"
+
 
 def _account_or_404(db: Session, account_id: uuid.UUID) -> models.FinancialAccount:
     account = (
@@ -97,6 +100,24 @@ def create_card(
         statement_day=payload.statement_day,
     )
     db.add(card)
+    db.flush()
+
+    # Every card gets a default category from the moment it exists, because
+    # untagged spend is resolved *to* the default when the cycle is totalled. A
+    # card with no categories has nowhere to put it, so the spend was computed
+    # and then dropped: set up a card, add a cap, spend on it, and the meter
+    # read zero — telling the user they had full headroom when they had none.
+    #
+    # Seeding one also removes the setup cliff. A new card is useful immediately
+    # ("what did I put on this card this cycle") instead of only after the user
+    # has built a taxonomy, and they can rename or add to it later.
+    db.add(models.CardCategory(
+        id=uuid.uuid7(),
+        card_id=card.id,
+        name=DEFAULT_CARD_CATEGORY_NAME,
+        is_default=True,
+        sort_order=0,
+    ))
     db.commit()
     db.refresh(card)
     return _card_response(card, account)
@@ -359,10 +380,18 @@ def delete_category(
             status_code=409,
             detail=f"{in_use} transaction(s) are tagged with this category. Retag them before deleting it.",
         )
-    if category.is_default and len(card.categories) > 1:
+    if category.is_default:
+        # A card must always have a default, because that is where untagged
+        # spend is resolved when the cycle is totalled. Without one the spend is
+        # computed and then dropped, and the meter reads zero.
         raise HTTPException(
             status_code=409,
-            detail="This is the card's default category. Make another category the default first.",
+            detail=(
+                "This is the card's default category, and untagged spending lands in it. "
+                + ("Make another category the default first."
+                   if len(card.categories) > 1
+                   else "A card needs at least one category — rename this one instead of deleting it.")
+            ),
         )
     db.delete(category)
     db.commit()

--- a/backend/tests/test_card_limits.py
+++ b/backend/tests/test_card_limits.py
@@ -483,7 +483,7 @@ class TestCardEndpoints:
         assert client.post("/cards", json=body, headers=headers).status_code == 201
         assert client.post("/cards", json=body, headers=headers).status_code == 409
 
-    def test_the_first_category_becomes_the_default_without_being_asked(
+    def test_a_category_added_later_does_not_steal_the_default(
         self, client, headers, card_account
     ):
         card = client.post(
@@ -491,14 +491,18 @@ class TestCardEndpoints:
             json={"financial_account_id": str(card_account.id), "statement_day": 18},
             headers=headers,
         ).json()
-        # Untagged spend has to land somewhere from the very first transaction.
+        # The card is seeded with a default, so a category added afterwards must
+        # not quietly steal it — untagged spend would move with it.
         res = client.post(
             f"/cards/{card['id']}/categories",
-            json={"name": "Everything else", "is_default": False},
+            json={"name": "Dining", "is_default": False},
             headers=headers,
         )
         assert res.status_code == 201
-        assert res.json()["is_default"] is True
+        assert res.json()["is_default"] is False
+
+        refreshed = client.get(f"/cards/{card['id']}", headers=headers).json()
+        assert [c["name"] for c in refreshed["categories"] if c["is_default"]] == ["Everything else"]
 
     def test_making_one_category_default_demotes_the_previous_one(
         self, client, headers, card_account
@@ -567,8 +571,8 @@ class TestCardEndpoints:
         assert client.delete(f"/cards/limits/{limit['id']}", headers=headers).status_code == 204
 
         refreshed = client.get(f"/cards/{card['id']}", headers=headers).json()
-        assert [c["name"] for c in refreshed["categories"]] == ["Dining"]
-        assert refreshed["categories"][0]["limit_id"] is None
+        dining = next(c for c in refreshed["categories"] if c["name"] == "Dining")
+        assert dining["limit_id"] is None, "the category survives, merely unmetered"
 
     def test_a_category_in_use_is_a_409_not_a_500(
         self, client, headers, db_session, card_account, dining
@@ -733,3 +737,59 @@ class TestTransactionIntegrity:
         )
         assert edited.status_code == 200
         assert edited.json()["card_category_id"] == cat["id"], "a description edit must not untag"
+
+
+class TestUntaggedSpendAlwaysLands:
+    """
+    Untagged spend is resolved *to* the card's default category when a cycle is
+    totalled. A card without a default has nowhere to put it, so the spend was
+    computed and then dropped — set a card up, add a cap, spend on it, and the
+    meter read zero. Telling someone they have full headroom when they have none
+    is the exact opposite of what this feature is for.
+    """
+
+    def test_a_new_card_can_meter_spending_immediately(self, client, headers, card_account, db_session, dining):
+        card = client.post(
+            "/cards",
+            json={"financial_account_id": str(card_account.id), "statement_day": 18},
+            headers=headers,
+        ).json()
+        assert [c["name"] for c in card["categories"] if c["is_default"]] == ["Everything else"], \
+            "a card is seeded with somewhere for untagged spend to land"
+
+        db_card = db_session.query(models.Card).filter(models.Card.id == uuid.UUID(card["id"])).first()
+        # No card category picked, exactly as a quick-add entry arrives.
+        _spend(db_session, card_account, dining, 250, date(2026, 9, 1))
+
+        db_session.refresh(db_card)
+        _, _, rows = card_service.card_category_breakdown(db_session, db_card, on=date(2026, 9, 5))
+        assert [(r.category.name, r.spent) for r in rows] == [("Everything else", Decimal("250.00"))]
+
+    def test_the_default_category_cannot_be_deleted_out_from_under_the_spend(
+        self, client, headers, card_account
+    ):
+        card = client.post(
+            "/cards",
+            json={"financial_account_id": str(card_account.id), "statement_day": 18},
+            headers=headers,
+        ).json()
+        default_id = next(c["id"] for c in card["categories"] if c["is_default"])
+
+        res = client.delete(f"/cards/categories/{default_id}", headers=headers)
+        assert res.status_code == 409
+        assert "at least one category" in res.json()["detail"]
+
+    def test_deleting_the_default_is_refused_while_another_could_take_over(
+        self, client, headers, card_account
+    ):
+        card = client.post(
+            "/cards",
+            json={"financial_account_id": str(card_account.id), "statement_day": 18},
+            headers=headers,
+        ).json()
+        default_id = next(c["id"] for c in card["categories"] if c["is_default"])
+        client.post(f"/cards/{card['id']}/categories", json={"name": "Dining"}, headers=headers)
+
+        res = client.delete(f"/cards/categories/{default_id}", headers=headers)
+        assert res.status_code == 409
+        assert "the default" in res.json()["detail"].lower()

--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback, useMemo} from "react";
-import { useNavigate, useRevalidator } from "react-router";
+import { useNavigate, useRevalidator, useFetcher } from "react-router";
 import { useCommandBar } from "../../lib/CommandBarContext";
 import { useHousehold } from "../../lib/HouseholdContext";
 import { useAuth } from "../../lib/AuthContext";
@@ -25,8 +25,9 @@ import {
     TradeView,
     TransferView,
 } from "./CommandBarViews";
-import type { AccountResponse, SubPortfolioResponse, TransactionResponse, CategoryResponse, AssetResponse, CardResponse, CardStatusResponse, CardLimitStatusRow } from "../../types/types";
-import { headroomByCategory, headroomLabel } from "../../lib/cards";
+import type { AccountResponse, SubPortfolioResponse, TransactionResponse, CategoryResponse, AssetResponse } from "../../types/types";
+import type { CardPickerData } from "../../pages/Transactions/cardCategories.resource";
+import { cardCategoryPickerOptions } from "../../lib/cards";
 
 
 export function CommandBar() {
@@ -48,7 +49,7 @@ export function CommandBar() {
     // The card behind the chosen account, if it is one. Fetched on demand — most
     // accounts are not cards, and the command bar is meant to be fast.
     const [cardCategoryId, setCardCategoryId] = useState("");
-    const [cardData, setCardData] = useState<{ card: CardResponse; headroom: Map<string, CardLimitStatusRow> } | null>(null);
+    const cardFetcher = useFetcher<CardPickerData>();
     const [successInfo, setSuccessInfo] = useState<{ big: string; sub: string } | null>(null);
     const [submitting, setSubmitting] = useState(false);
     const [undoData, setUndoData] = useState<{ path: string } | null>(null);
@@ -168,39 +169,21 @@ export function CommandBar() {
         ?? (parsed.type === "expense" ? routedAccount(parsed.account)?.id : undefined)
         ?? null;
 
+    // Reuses the resource route the transaction form already loads this from,
+    // rather than a second copy of "find the card, then fetch its status".
     useEffect(() => {
-        let cancelled = false;
         setCardCategoryId("");
-        if (!activeHousehold || !chosenAccountId) { setCardData(null); return; }
-        (async () => {
-            try {
-                const { data: cards } = await api.get<CardResponse[]>(`/cards/household/${activeHousehold.id}`);
-                const card = cards.find(c => c.financial_account_id === chosenAccountId);
-                if (!card) { if (!cancelled) setCardData(null); return; }
-                const { data: status } = await api.get<CardStatusResponse>(`/cards/${card.id}/status`);
-                if (!cancelled) setCardData({ card, headroom: headroomByCategory(card, status) });
-            } catch {
-                // A missing meter makes the picker plainer, never the bar unusable.
-                if (!cancelled) setCardData(null);
-            }
-        })();
-        return () => { cancelled = true; };
-    }, [activeHousehold, chosenAccountId]);
+        if (chosenAccountId) cardFetcher.load(`/transactions/card/${chosenAccountId}`);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [chosenAccountId]);
 
-    const cardCategoryOptions = useMemo(() => {
-        if (!cardData) return [];
-        const money = (v: number) => new Intl.NumberFormat(undefined, {
-            style: "currency", currency: cardData.card.currency || activeHousehold?.base_currency || "USD",
-            maximumFractionDigits: 0,
-        }).format(v);
-        return [
-            { value: "", label: "— Card's default —" },
-            ...cardData.card.categories.map(c => {
-                const row = cardData.headroom.get(c.id);
-                return { value: c.id, label: row ? `${c.name} · ${headroomLabel(row, money)}` : c.name };
-            }),
-        ];
-    }, [cardData, activeHousehold]);
+    const cardCategoryOptions = useMemo(
+        () => cardCategoryPickerOptions(
+            cardFetcher.data ?? null,
+            activeHousehold?.base_currency ?? "USD",
+        ),
+        [cardFetcher.data, activeHousehold],
+    );
 
     if (!isOpen) return null;
 

--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState, useCallback } from "react";
+import { useEffect, useRef, useState, useCallback, useMemo} from "react";
 import { useNavigate, useRevalidator } from "react-router";
 import { useCommandBar } from "../../lib/CommandBarContext";
 import { useHousehold } from "../../lib/HouseholdContext";
@@ -25,7 +25,8 @@ import {
     TradeView,
     TransferView,
 } from "./CommandBarViews";
-import type { AccountResponse, SubPortfolioResponse, TransactionResponse, CategoryResponse, AssetResponse } from "../../types/types";
+import type { AccountResponse, SubPortfolioResponse, TransactionResponse, CategoryResponse, AssetResponse, CardResponse, CardStatusResponse, CardLimitStatusRow } from "../../types/types";
+import { headroomByCategory, headroomLabel } from "../../lib/cards";
 
 
 export function CommandBar() {
@@ -44,6 +45,10 @@ export function CommandBar() {
     const [selectedSubPortfolioId, setSelectedSubPortfolioId] = useState<string | null>(null);
     const [categoryOverride, setCategoryOverride] = useState<{ name: string; icon: string } | null>(null);
     const [expenseAccountId, setExpenseAccountId] = useState<string | null>(null);
+    // The card behind the chosen account, if it is one. Fetched on demand — most
+    // accounts are not cards, and the command bar is meant to be fast.
+    const [cardCategoryId, setCardCategoryId] = useState("");
+    const [cardData, setCardData] = useState<{ card: CardResponse; headroom: Map<string, CardLimitStatusRow> } | null>(null);
     const [successInfo, setSuccessInfo] = useState<{ big: string; sub: string } | null>(null);
     const [submitting, setSubmitting] = useState(false);
     const [undoData, setUndoData] = useState<{ path: string } | null>(null);
@@ -148,6 +153,54 @@ export function CommandBar() {
         };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [isOpen, activeTicker, parsed.type]);
+
+    const routedAccount = (fallback: AccountResponse | null): AccountResponse | null => {
+        const userDefault = accounts.find(a => a.id === user?.default_account_id) || null;
+        if (!hasHousehold) return fallback || userDefault;
+        if (ownership === "private") {
+            return accounts.find(a => a.owner_user_id === user?.id) || fallback || userDefault;
+        }
+        return accounts.find(a => !a.owner_user_id) || fallback || userDefault;
+    };
+
+    // The account the expense will actually be charged to.
+    const chosenAccountId = expenseAccountId
+        ?? (parsed.type === "expense" ? routedAccount(parsed.account)?.id : undefined)
+        ?? null;
+
+    useEffect(() => {
+        let cancelled = false;
+        setCardCategoryId("");
+        if (!activeHousehold || !chosenAccountId) { setCardData(null); return; }
+        (async () => {
+            try {
+                const { data: cards } = await api.get<CardResponse[]>(`/cards/household/${activeHousehold.id}`);
+                const card = cards.find(c => c.financial_account_id === chosenAccountId);
+                if (!card) { if (!cancelled) setCardData(null); return; }
+                const { data: status } = await api.get<CardStatusResponse>(`/cards/${card.id}/status`);
+                if (!cancelled) setCardData({ card, headroom: headroomByCategory(card, status) });
+            } catch {
+                // A missing meter makes the picker plainer, never the bar unusable.
+                if (!cancelled) setCardData(null);
+            }
+        })();
+        return () => { cancelled = true; };
+    }, [activeHousehold, chosenAccountId]);
+
+    const cardCategoryOptions = useMemo(() => {
+        if (!cardData) return [];
+        const money = (v: number) => new Intl.NumberFormat(undefined, {
+            style: "currency", currency: cardData.card.currency || activeHousehold?.base_currency || "USD",
+            maximumFractionDigits: 0,
+        }).format(v);
+        return [
+            { value: "", label: "— Card's default —" },
+            ...cardData.card.categories.map(c => {
+                const row = cardData.headroom.get(c.id);
+                return { value: c.id, label: row ? `${c.name} · ${headroomLabel(row, money)}` : c.name };
+            }),
+        ];
+    }, [cardData, activeHousehold]);
 
     if (!isOpen) return null;
 
@@ -270,15 +323,6 @@ export function CommandBar() {
     /** When ownership routing is shown, resolve which real account to charge: the user's own
      * private account if "private" is chosen, otherwise a shared (owner_user_id null) account.
      * Falls back to whatever the parser matched if no account of the right kind exists. */
-    const routedAccount = (fallback: AccountResponse | null): AccountResponse | null => {
-        const userDefault = accounts.find(a => a.id === user?.default_account_id) || null;
-        if (!hasHousehold) return fallback || userDefault;
-        if (ownership === "private") {
-            return accounts.find(a => a.owner_user_id === user?.id) || fallback || userDefault;
-        }
-        return accounts.find(a => !a.owner_user_id) || fallback || userDefault;
-    };
-
     const finishSuccess = (big: string, sub: string, undo: { path: string } | null) => {
         setSuccessInfo({ big, sub });
         setUndoData(undo);
@@ -315,6 +359,9 @@ export function CommandBar() {
                     amount: parsed.amount,
                     transaction_type: "expense",
                     description: parsed.merchant,
+                    // Omitted when blank: the API reads a missing key as "use the
+                    // card's default", which is what blank means here.
+                    ...(cardCategoryId ? { card_category_id: cardCategoryId } : {}),
                 });
                 finishSuccess(`−$${fmtA(parsed.amount)}`, `${category.name} · ${account.name}${!expenseAccountId && hasHousehold ? (ownership === "private" ? " · Private" : " · Household") : ""}`, { path: `/cashflow/transactions/${res.data.id}` });
             } else if (parsed.type === "balance") {
@@ -521,6 +568,9 @@ export function CommandBar() {
                             setQuery={setQuery}
                             categoryOverride={categoryOverride}
                             setCategoryOverride={setCategoryOverride}
+                            cardCategoryOptions={cardCategoryOptions}
+                            cardCategoryId={cardCategoryId}
+                            setCardCategoryId={setCardCategoryId}
                             expenseAccountId={expenseAccountId}
                             setExpenseAccountId={setExpenseAccountId}
                         />

--- a/frontend/src/components/CommandBar/CommandBarViews.tsx
+++ b/frontend/src/components/CommandBar/CommandBarViews.tsx
@@ -11,6 +11,7 @@ import {
 } from "../../lib/commandParser";
 import type { ScanResult } from "./receiptScan";
 import { Select } from "../ui/Select";
+import { selectableAccounts } from "../../lib/networth";
 import type {
     AccountResponse,
     AssetResponse,
@@ -88,7 +89,7 @@ export function RestingView({ recent, accounts, onDemo }: { recent: TransactionR
     );
 }
 
-export function ExpenseView({ parsed, defaultAccount, scanned, hasHousehold, ownership, setOwnership, accounts, setQuery, categoryOverride, setCategoryOverride, expenseAccountId, setExpenseAccountId }: {
+export function ExpenseView({ parsed, defaultAccount, scanned, hasHousehold, ownership, setOwnership, accounts, setQuery, categoryOverride, setCategoryOverride, expenseAccountId, setExpenseAccountId, cardCategoryOptions, cardCategoryId, setCardCategoryId }: {
     parsed: Extract<ParsedCommand, { type: "expense" }>;
     defaultAccount: AccountResponse | null;
     scanned: ScanResult | null;
@@ -101,6 +102,10 @@ export function ExpenseView({ parsed, defaultAccount, scanned, hasHousehold, own
     setCategoryOverride: (v: { name: string; icon: string } | null) => void;
     expenseAccountId: string | null;
     setExpenseAccountId: (v: string | null) => void;
+    /** Empty unless the chosen account is a card. Labels carry this cycle's headroom. */
+    cardCategoryOptions: { value: string; label: string }[];
+    cardCategoryId: string;
+    setCardCategoryId: (v: string) => void;
 }) {
     const category = categoryOverride || parsed.category;
     const effectiveAccount = expenseAccountId ? accounts.find(a => a.id === expenseAccountId) || null : defaultAccount;
@@ -169,12 +174,28 @@ export function ExpenseView({ parsed, defaultAccount, scanned, hasHousehold, own
                         className="rounded-lg bg-base-50 dark:bg-base-950 focus-visible:ring-secondary-400"
                         value={effectiveAccount?.id || ""}
                         onChange={(id) => setExpenseAccountId(id || null)}
-                        options={accounts.map(a => ({ value: a.id, label: `${a.name} · ${a.currency}` }))}
+                        options={selectableAccounts(accounts).map(a => ({ value: a.id, label: `${a.name} · ${a.currency}` }))}
                     />
                 ) : (
                     <div className="text-xs text-red-500">No account available to charge yet.</div>
                 )}
             </div>
+            {/* Only when the chosen account is a card. Quick add is a reduced
+                surface — no split, no merchant code — but this row carries the
+                headroom, and logging card spend is when that can change a
+                decision. */}
+            {cardCategoryOptions.length > 0 && (
+                <div>
+                    <div className={labelClass}>Card category</div>
+                    <Select
+                        size="sm"
+                        className="rounded-lg bg-base-50 dark:bg-base-950 focus-visible:ring-secondary-400"
+                        value={cardCategoryId}
+                        onChange={setCardCategoryId}
+                        options={cardCategoryOptions}
+                    />
+                </div>
+            )}
             {hasHousehold && (
                 <div>
                     <div className={labelClass}>Post this expense to</div>

--- a/frontend/src/lib/cards.test.ts
+++ b/frontend/src/lib/cards.test.ts
@@ -5,6 +5,7 @@ import {
     cycleLabel,
     headroomByCategory,
     limitsNeedingAttention,
+    limitMeasuresNothing,
 } from './cards';
 import type { CardLimitStatusRow } from '../types/types';
 
@@ -133,5 +134,18 @@ describe('limitsNeedingAttention', () => {
 
     it('is empty when everything is fine, so the Dashboard shows nothing', () => {
         expect(limitsNeedingAttention([row(), row()])).toEqual([]);
+    });
+});
+
+describe('limitMeasuresNothing', () => {
+    it('flags a limit nothing points at', () => {
+        // A cap with no categories draws a plausible "0 of $1,000" bar that
+        // reads as "nothing spent yet" — the one thing it must not be mistaken
+        // for.
+        expect(limitMeasuresNothing(row({ category_names: [] }))).toBe(true);
+    });
+
+    it('leaves a wired-up limit alone', () => {
+        expect(limitMeasuresNothing(row({ category_names: ['Dining'] }))).toBe(false);
     });
 });

--- a/frontend/src/lib/cards.ts
+++ b/frontend/src/lib/cards.ts
@@ -1,4 +1,4 @@
-import type { CardLimitStatusRow, CardResponse, CardStatusResponse } from "../types/types";
+import type { CardCategoryResponse, CardLimitStatusRow, CardResponse, CardStatusResponse } from "../types/types";
 
 /**
  * Presentation logic for per-card spend limits.
@@ -118,4 +118,36 @@ export function headroomByCategory(
  */
 export function limitsNeedingAttention(rows: CardLimitStatusRow[]): CardLimitStatusRow[] {
     return rows.filter(row => cardLimitTone(row) !== "ok");
+}
+
+
+/**
+ * The card-category picker's options, headroom and all.
+ *
+ * Shared by the transaction form and the command bar so the two cannot drift
+ * into saying different things about the same card. Takes the resource route's
+ * payload directly — `{ card: null }` is the ordinary answer for an account
+ * that is not a card, and yields no options at all, which is what hides the
+ * picker.
+ */
+export function cardCategoryPickerOptions(
+    data: { card: CardResponse | null; status: CardStatusResponse | null } | null,
+    fallbackCurrency: string
+): { value: string; label: string }[] {
+    if (!data?.card) return [];
+    const currency = data.card.currency || fallbackCurrency;
+    const money = (value: number) =>
+        new Intl.NumberFormat(undefined, {
+            style: "currency",
+            currency,
+            maximumFractionDigits: 0,
+        }).format(value);
+    const headroom = data.status ? headroomByCategory(data.card, data.status) : new Map();
+    return [
+        { value: "", label: "— Card's default —" },
+        ...data.card.categories.map((c: CardCategoryResponse) => {
+            const row = headroom.get(c.id);
+            return { value: c.id, label: row ? `${c.name} · ${headroomLabel(row, money)}` : c.name };
+        }),
+    ];
 }

--- a/frontend/src/lib/cards.ts
+++ b/frontend/src/lib/cards.ts
@@ -21,6 +21,20 @@ export type CardLimitTone = "over" | "at-risk" | "ok";
  * showing — a warning after the cycle closes is useless, so the pace projection
  * is what earns its place.
  */
+/**
+ * A limit with no categories pointing at it measures nothing.
+ *
+ * It is a setup mistake rather than a state worth rendering as a meter: the user
+ * made a cap and never said what counts towards it. Left alone it draws a
+ * perfectly plausible "0 of $1,000" bar and reads as "nothing spent yet",
+ * which is the one thing it must not be mistaken for.
+ */
+export function limitMeasuresNothing(
+    row: Pick<CardLimitStatusRow, "category_names">
+): boolean {
+    return row.category_names.length === 0;
+}
+
 export function cardLimitTone(
     row: Pick<CardLimitStatusRow, "direction" | "settled" | "projected_missed">
 ): CardLimitTone {

--- a/frontend/src/pages/Cards/CardMeters.tsx
+++ b/frontend/src/pages/Cards/CardMeters.tsx
@@ -2,7 +2,7 @@ import { Form } from "react-router";
 import { Trash2 } from "lucide-react";
 import { Badge } from "../../components/ui/Badge";
 import { budgetBarPercent, periodElapsedPercent } from "../../lib/budgets";
-import { cardLimitTone, headroomLabel, type CardLimitTone } from "../../lib/cards";
+import { cardLimitTone, headroomLabel, limitMeasuresNothing, type CardLimitTone } from "../../lib/cards";
 import { cn } from "../../lib/utils";
 import type { CardCategorySpendRow, CardLimitStatusRow } from "../../types/types";
 
@@ -77,6 +77,12 @@ export function LimitMeter({
                     aria-hidden="true"
                 />
             </div>
+
+            {limitMeasuresNothing(row) && (
+                <p className="text-xs text-amber-600 dark:text-amber-400">
+                    No categories point at this limit yet, so it isn't measuring anything.
+                </p>
+            )}
 
             {tone === "at-risk" && (
                 <p className="text-xs text-amber-600 dark:text-amber-400">

--- a/frontend/src/pages/Transactions/Transactions.tsx
+++ b/frontend/src/pages/Transactions/Transactions.tsx
@@ -11,7 +11,7 @@ import { downloadFromApi } from "../../lib/download"
 import type { HistoryLoaderData } from "./transactions.loader"
 import type { MccResponse } from "../../types/types"
 import type { CardPickerData } from "./cardCategories.resource"
-import { headroomByCategory, headroomLabel } from "../../lib/cards"
+import { cardCategoryPickerOptions } from "../../lib/cards"
 import { Input } from "../../components/ui/Input"
 import { Select } from "../../components/ui/Select"
 import { TopBar } from "../../components/TopBar"
@@ -117,29 +117,11 @@ export default function Transactions() {
     };
 
     // "Dining · $240 left" at the moment of choosing — the one point where the
-    // number can still change the decision.
-    const cardCategoryOptions = useMemo(() => {
-        if (!cardData?.card) return [];
-        const money = (value: number) =>
-            new Intl.NumberFormat(undefined, {
-                style: "currency",
-                currency: cardData.card?.currency || activeHousehold?.base_currency || "USD",
-                maximumFractionDigits: 0,
-            }).format(value);
-        const headroom = cardData.status
-            ? headroomByCategory(cardData.card, cardData.status)
-            : new Map();
-        return [
-            { value: "", label: "— Card's default —" },
-            ...cardData.card.categories.map(c => {
-                const row = headroom.get(c.id);
-                return {
-                    value: c.id,
-                    label: row ? `${c.name} · ${headroomLabel(row, money)}` : c.name,
-                };
-            }),
-        ];
-    }, [cardData, activeHousehold]);
+    // number can still change the decision. Shared with the command bar.
+    const cardCategoryOptions = useMemo(
+        () => cardCategoryPickerOptions(cardData, activeHousehold?.base_currency ?? "USD"),
+        [cardData, activeHousehold],
+    );
 
     const openLogModal = () => {
         setIsLogModalOpen(true);

--- a/ios/FinanceTracker/Support/Cards.swift
+++ b/ios/FinanceTracker/Support/Cards.swift
@@ -80,6 +80,16 @@ enum Cards {
         return out
     }
 
+    /// A limit with no categories pointing at it measures nothing.
+    ///
+    /// A setup mistake rather than a state worth rendering as a meter: the user
+    /// made a cap and never said what counts towards it. Left alone it draws a
+    /// perfectly plausible "0 of $1,000" bar and reads as "nothing spent yet",
+    /// which is the one thing it must not be mistaken for.
+    static func measuresNothing(_ row: CardLimitStatusRow) -> Bool {
+        row.categoryNames.isEmpty
+    }
+
     /// The limits worth interrupting someone about — burst, or on pace to be.
     ///
     /// Used for the Dashboard's exception row, which shows nothing at all when

--- a/ios/FinanceTracker/Support/Cards.swift
+++ b/ios/FinanceTracker/Support/Cards.swift
@@ -80,6 +80,29 @@ enum Cards {
         return out
     }
 
+    /// The card behind an account, with this cycle's headroom — or nil, which is
+    /// the ordinary answer for an account that is not a card rather than an error.
+    ///
+    /// Shared by the transaction form and Quick Add so the two cannot drift into
+    /// saying different things about the same card. Fetched on demand at both
+    /// call sites, because most accounts are not cards and most households have
+    /// none.
+    static func load(
+        householdId: String,
+        accountId: String
+    ) async -> (card: CardResponse, headroom: [String: CardLimitStatusRow])? {
+        do {
+            let cards: [CardResponse] = try await APIClient.shared.get("/cards/household/\(householdId)")
+            guard let card = cards.first(where: { $0.financialAccountId == accountId }) else { return nil }
+            // A missing meter makes the picker plainer, never the form unusable,
+            // so the status is allowed to fail on its own.
+            let status: CardStatusResponse? = try? await APIClient.shared.get("/cards/\(card.id)/status")
+            return (card, status.map { headroomByCategory(card: card, status: $0) } ?? [:])
+        } catch {
+            return nil
+        }
+    }
+
     /// A limit with no categories pointing at it measures nothing.
     ///
     /// A setup mistake rather than a state worth rendering as a meter: the user

--- a/ios/FinanceTracker/Views/More/CardsView.swift
+++ b/ios/FinanceTracker/Views/More/CardsView.swift
@@ -193,6 +193,12 @@ struct CardLimitMeter: View {
             }
             .frame(height: 6)
 
+            if Cards.measuresNothing(row) {
+                Text("No categories point at this limit yet, so it isn't measuring anything.")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+
             if Cards.tone(for: row) == .atRisk {
                 Text(
                     row.direction == .floor

--- a/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
+++ b/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
@@ -50,6 +50,11 @@ struct QuickAddView: View {
     // Cash-flow fields
     @State private var accountId: String?
     @State private var categoryId: String?
+    /// The card behind the selected account, if it is one. Fetched on demand —
+    /// most accounts are not cards, and Quick Add is meant to be fast.
+    @State private var card: CardResponse?
+    @State private var cardHeadroom: [String: CardLimitStatusRow] = [:]
+    @State private var cardCategoryId: String?
     @State private var fromAccountId: String?
     @State private var toAccountId: String?
 
@@ -142,6 +147,11 @@ struct QuickAddView: View {
             )
             .task { await loadIfNeeded() }
             .onChange(of: mode) { resetForMode() }
+            .onChange(of: accountId) { _, newValue in
+                // A pick from the old card is meaningless on a new one.
+                cardCategoryId = nil
+                Task { await loadCard(for: newValue) }
+            }
             .sheet(isPresented: $showingNewCategory) {
                 if let household {
                     CategoryEditView(category: nil, householdId: household.id, lockedType: mode == .income ? .income : .expense) { created in
@@ -205,6 +215,20 @@ struct QuickAddView: View {
                     showingNewCategory = true
                 } label: {
                     Label("New Category", systemImage: "plus.circle")
+                }
+            }
+            // Only when the account is a card. Quick Add is a deliberately
+            // reduced surface — it leaves out the split and the merchant code —
+            // but this one earns its row: it carries the headroom, and logging
+            // card spend is exactly when that number can change a decision.
+            if let card {
+                Section {
+                    Picker("Card category", selection: $cardCategoryId) {
+                        Text("Card's default").tag(String?.none)
+                        ForEach(card.categories) { category in
+                            Text(cardCategoryLabel(category)).tag(String?.some(category.id))
+                        }
+                    }
                 }
             }
         }
@@ -350,6 +374,38 @@ struct QuickAddView: View {
 
     // MARK: - Data
 
+    /// The card behind an account, with this cycle's headroom — or nothing, which
+    /// is the common answer rather than an error.
+    private func loadCard(for accountId: String?) async {
+        guard let householdId = session.activeHousehold?.id, let accountId else {
+            card = nil
+            cardHeadroom = [:]
+            return
+        }
+        do {
+            let cards: [CardResponse] = try await APIClient.shared.get("/cards/household/\(householdId)")
+            guard let match = cards.first(where: { $0.financialAccountId == accountId }) else {
+                card = nil
+                cardHeadroom = [:]
+                cardCategoryId = nil
+                return
+            }
+            card = match
+            let status: CardStatusResponse = try await APIClient.shared.get("/cards/\(match.id)/status")
+            cardHeadroom = Cards.headroomByCategory(card: match, status: status)
+        } catch {
+            // A missing meter makes the picker plainer, never the sheet unusable.
+            cardHeadroom = [:]
+        }
+    }
+
+    /// "Dining · $240 left" when the category is metered, otherwise just its name.
+    private func cardCategoryLabel(_ category: CardCategoryResponse) -> String {
+        guard let row = cardHeadroom[category.id] else { return category.name }
+        let currency = card?.currency ?? session.activeHousehold?.baseCurrency ?? "USD"
+        return "\(category.name) · \(Cards.headroomLabel(for: row) { $0.currencyWhole(currency) })"
+    }
+
     private func loadIfNeeded() async {
         guard !loaded, let household else { return }
         do {
@@ -423,7 +479,8 @@ struct QuickAddView: View {
             body: TransactionCreate(
                 date: date, amount: amount,
                 description: description.isEmpty ? nil : description,
-                accountId: accountId, categoryId: categoryId
+                accountId: accountId, categoryId: categoryId,
+                cardCategoryId: cardCategoryId
             )
         )
     }

--- a/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
+++ b/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
@@ -382,21 +382,13 @@ struct QuickAddView: View {
             cardHeadroom = [:]
             return
         }
-        do {
-            let cards: [CardResponse] = try await APIClient.shared.get("/cards/household/\(householdId)")
-            guard let match = cards.first(where: { $0.financialAccountId == accountId }) else {
-                card = nil
-                cardHeadroom = [:]
-                cardCategoryId = nil
-                return
-            }
-            card = match
-            let status: CardStatusResponse = try await APIClient.shared.get("/cards/\(match.id)/status")
-            cardHeadroom = Cards.headroomByCategory(card: match, status: status)
-        } catch {
-            // A missing meter makes the picker plainer, never the sheet unusable.
+        guard let loaded = await Cards.load(householdId: householdId, accountId: accountId) else {
+            card = nil
             cardHeadroom = [:]
+            return
         }
+        card = loaded.card
+        cardHeadroom = loaded.headroom
     }
 
     /// "Dining · $240 left" when the category is metered, otherwise just its name.

--- a/ios/FinanceTracker/Views/Transactions/TransactionForms.swift
+++ b/ios/FinanceTracker/Views/Transactions/TransactionForms.swift
@@ -285,27 +285,18 @@ struct TransactionFormView: View {
     /// is the common answer rather than an error. Fetched on demand because most
     /// accounts are not cards and most households have none.
     private func loadCard(for accountId: String?) async {
-        guard let accountId else {
+        guard let householdId = session.activeHousehold?.id, let accountId else {
             card = nil
             cardHeadroom = [:]
             return
         }
-        do {
-            let cards: [CardResponse] = try await APIClient.shared.get(
-                "/cards/household/\(householdId)"
-            )
-            guard let match = cards.first(where: { $0.financialAccountId == accountId }) else {
-                card = nil
-                cardHeadroom = [:]
-                return
-            }
-            card = match
-            let status: CardStatusResponse = try await APIClient.shared.get("/cards/\(match.id)/status")
-            cardHeadroom = Cards.headroomByCategory(card: match, status: status)
-        } catch {
-            // A missing meter makes the picker plainer, not the form unusable.
+        guard let loaded = await Cards.load(householdId: householdId, accountId: accountId) else {
+            card = nil
             cardHeadroom = [:]
+            return
         }
+        card = loaded.card
+        cardHeadroom = loaded.headroom
     }
 
     /// "Dining · $240 left" when the category is metered, otherwise just its name.


### PR DESCRIPTION
Two things, and the second one is a real bug in what shipped.

## 1. Card category in Quick Add

The headroom picker was on the full transaction form but missing from every quick-add surface — the web command bar, iOS QuickAdd, Android's QuickAddSheet — which is where card spend actually gets logged.

Quick add is a **deliberately reduced surface**: it already leaves out the split-bill fields the full form has. So the question wasn't "add the missing fields" but which of them earn a row there. **The card category does; the merchant code doesn't.** The card picker isn't data capture — it carries the headroom (`Dining · $240 left`), and logging card spend is exactly the moment that number can change a decision. The merchant code is blank by default, hidden behind a per-user toggle, and gives nothing back, so in a flow built for speed it's pure friction. It stays out.

All three fetch the card on demand when the chosen account changes, because most accounts aren't cards. Blank means the card's default — which is where untagged spend was already being metered — so this changes what you *can* say, not what happens if you say nothing.

Two things the web change turned up:

- **`routedAccount` had to be hoisted** above the `if (!isOpen) return null` guard so the picker and the submit resolve the *same* account. Approximating it would have shown headroom for one account while charging another.
- My first placement put the new hooks **below** that guard — a rules-of-hooks violation. The CommandBar tests caught it (`Rendered more hooks than during the previous render`). That's the second time this early-return-between-hooks shape has bitten this codebase; the first was `Portfolio.tsx` during the split.

## 2. A card's spending could vanish into no category

Reported as *"I put a transaction on the credit card but the cards screen still shows $0 spent"*, and reproduced exactly: a $250 expense, the status endpoint reporting `0.00` and no categories at all.

Untagged spend is resolved **to** the card's default category when a cycle is totalled. A card with no categories has no default, so the money landed under a null key and both the breakdown and the limit rollup dropped it. The failure mode is the worst available — not an error, but a plausible zero telling someone they have **full headroom when they have none**, which is the exact opposite of what this feature is for.

Three changes, because any one alone leaves the hole reachable:

- `create_card` seeds an **"Everything else"** default, so untagged spend has somewhere to land from the card's first transaction. It also removes the setup cliff — a new card answers "what did I put on this cycle" immediately rather than only after the user builds a taxonomy.
- **Deleting the default is refused outright**, not just when another category exists. Deleting the last one reopened the hole.
- A **backfill** seeds existing cards and promotes a default where categories exist but none is marked. Deliberately not reversed on downgrade: removing a card's only category would restore the bug, and by then the row may hold transactions.

### The second silence

The other half of the report is separate and was *correct* behaviour: a limit with no categories pointing at it genuinely measures nothing — but it drew a plausible `0 of $12,000` bar, indistinguishable from the bug above. `measuresNothing` is a new parity trio and all three clients now say so explicitly.

## Notes for review

- **Two existing tests changed premise rather than regressed.** The first user-created category is no longer the default (the seeded one is), so that test now pins the *stronger* rule: a category added later must not silently steal the default and take untagged spend with it.
- **Deploy split:** the `$0 spent` fix is backend-only and reaches production on the next Cloud Build. The `measuresNothing` notice is web + both natives; the native half needs app rebuilds, which Cloud Build doesn't cover.
- The backfill runs on container boot, so existing cards get their default automatically — no user action needed for the spend to reappear. Attaching that category to a *limit* stays a deliberate choice.

## Verification

Backend **543 passed**, single migration head · web **179 passed / 20 files** · iOS **TEST SUCCEEDED** · Android **BUILD SUCCESSFUL**. TypeScript at the 35-error `dev` baseline — none new.

The reported bug was reproduced against the running stack before the fix and re-checked after: the $250 now appears under "Everything else".

**Not verified:** none of the native screens have been driven in a simulator or emulator — same gap as #265.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
