### PR TITLE
fix(ios,android,web): fill Quick Add's pickers before it opens (#272)

### DIFF
--- a/android/AGENTS.md
+++ b/android/AGENTS.md
@@ -48,6 +48,8 @@ android/app/src/main/java/com/ivanlee/financetracker/
   state/SessionViewModel.kt  # auth, user, households, active household (mirrors SessionStore)
   state/ViewModeViewModel.kt # Private/Household/Blended + vault lock (mirrors ViewModeStore)
   state/QuickAddViewModel.kt # command-sheet presentation + reloadToken
+  state/ReferenceDataViewModel.kt # the accounts/categories/sub-portfolios/assets Quick Add
+                             #   fills its pickers from, loaded once per household at the app root
   logic/                     # PURE, JVM-testable: PortfolioAnalytics, GoalProjection, NetWorth,
                              #   BudgetPresentation, Formatters, ViewModeVisibility, CategoryPeriod
                              #   (the Top-Categories date window; its SharedPreferences half lives
@@ -211,6 +213,27 @@ per sub-portfolio inside the Portfolio tab and drilled into via `GoalDetailScree
   trigger **and** the finger lifts below `FLICK_VELOCITY` — without the velocity gate a fast
   flick back to the top of a long list opens it too, which is what "too sensitive" means in
   practice.
+- **Quick Add's pickers come from `ReferenceDataViewModel`, not from a fetch on open**
+  (loaded by `MainScaffold` on the active household and re-loaded on
+  `QuickAddViewModel.reloadToken`; the Kotlin twin of iOS's `ReferenceDataStore`). The sheet
+  used to fetch accounts, categories, sub-portfolios and assets from inside itself — and
+  because `MainScaffold` only composes it under `if (quickAddVm.isPresented)`, that happened on
+  *every* open, not just the first. On a cold start over a real network the account picker
+  therefore sat on "Select…" for a full round trip, which reads as "this household has no
+  accounts" (#272). Three rules it encodes, all shared with iOS:
+    - **Accounts and categories are published before the portfolio sets are awaited**
+      (`Essentials` → `Ready`). An expense is the default mode and needs only those two; the
+      defaults used to wait on all four, so the account stayed unselected until
+      `/portfolio/assets` came back.
+    - **`hasEssentials` is a latch, not a reading of `status`.** A refresh that fails leaves the
+      previous accounts and categories in place and they are still the best answer available.
+    - **The sheet says which of three states it is in**: still loading (spinner), failed (the
+      message plus a Retry that force-reloads), or genuinely empty (no accounts yet). Leaving
+      every picker on "Select…" for all three is the bug.
+  Note the queueing amplifier iOS has does **not** exist here: `Api` uses OkHttp `execute()` on
+  `Dispatchers.IO`, which isn't bounded by OkHttp's async dispatcher, so a screen's requests all
+  start at once rather than queueing six at a time. The empty window was one round trip here
+  and several seconds on iOS — same defect, different blast radius.
 - **Swipe rows** (`ui/components/SwipeRow.kt`) use `SwipeToDismissBox` but never complete the
   dismissal: `confirmValueChange` fires the action and returns false, so the row springs back.
   That's right here because every destructive action goes through a confirmation dialog — a row
@@ -281,6 +304,11 @@ where tests pay off without a backend or an emulator:
   plus the Today/Yesterday rule pinned from both sides of UTC. The label tests pass an explicit
   `localZone`; leaving it to `ZoneId.systemDefault()` makes them agree or disagree depending on
   where the build machine is.
+- `ReferenceDataViewModelTest` — the non-fetching half of `state/ReferenceDataViewModel.kt`:
+  that no household is `Idle` rather than a failure, that `hasEssentials` survives a *failed
+  refresh* (the regression that reproduces #272's empty picker), and that a row created inside
+  Quick Add folds in without duplicating when the next refresh returns it. Twin of iOS's
+  `ReferenceDataStoreTests`.
 - `ApiUrlTest` — query-string splitting.
 - `FormattersTest` — dates asserted exactly (they're UTC by design); currency gets structural
   checks only, since its digit grouping comes from the JVM's locale data rather than from us.

--- a/android/app/src/main/java/com/ivanlee/financetracker/MainActivity.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.ivanlee.financetracker.state.QuickAddViewModel
+import com.ivanlee.financetracker.state.ReferenceDataViewModel
 import com.ivanlee.financetracker.state.SessionViewModel
 import com.ivanlee.financetracker.state.ViewModeViewModel
 import com.ivanlee.financetracker.ui.MainScaffold
@@ -48,6 +49,7 @@ fun WaypointRoot() {
     val sessionVm: SessionViewModel = viewModel()
     val viewModeVm: ViewModeViewModel = viewModel()
     val quickAddVm: QuickAddViewModel = viewModel()
+    val referenceVm: ReferenceDataViewModel = viewModel()
 
     LaunchedEffect(Unit) { sessionVm.bootstrap() }
 
@@ -66,7 +68,7 @@ fun WaypointRoot() {
                 // it finishes — see SessionViewModel.needsOnboarding.
                 sessionVm.needsOnboarding -> OnboardingScreen(sessionVm)
 
-                else -> MainScaffold(sessionVm, viewModeVm, quickAddVm)
+                else -> MainScaffold(sessionVm, viewModeVm, quickAddVm, referenceVm)
             }
         }
     }

--- a/android/app/src/main/java/com/ivanlee/financetracker/state/ReferenceDataViewModel.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/state/ReferenceDataViewModel.kt
@@ -1,0 +1,180 @@
+package com.ivanlee.financetracker.state
+
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.ivanlee.financetracker.data.model.AccountResponse
+import com.ivanlee.financetracker.data.model.AssetResponse
+import com.ivanlee.financetracker.data.model.CategoryResponse
+import com.ivanlee.financetracker.data.model.SubPortfolioResponse
+import com.ivanlee.financetracker.data.net.Api
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * The reference sets Quick Add fills its pickers from — accounts, categories, sub-portfolios
+ * and assets — held at the app root and loaded once per household instead of once per sheet.
+ * Mirrors ios/FinanceTracker/State/ReferenceDataStore.swift.
+ *
+ * Quick Add used to fetch all four from inside the sheet, and because `MainScaffold` only
+ * composes the sheet while it is presented, that happened on *every* open. On a cold start
+ * over a real network the account picker therefore sat on "Select…" for a full round trip —
+ * indistinguishable from "this household has no accounts", which is what made people close it
+ * and go to the Accounts tab to wake the data up (#272). Loading when the household resolves
+ * means the sheet almost always opens with its pickers already filled, and reopening is free.
+ *
+ * Accounts and categories are published **before** the portfolio sets are awaited: an expense
+ * is the default mode and needs only those two, and making it wait on `/portfolio/assets`
+ * buys it nothing.
+ */
+class ReferenceDataViewModel : ViewModel() {
+
+    /** What the pickers can offer right now, and whether more is still coming. */
+    sealed interface Status {
+        /** No household yet, so there is nothing to load. */
+        data object Idle : Status
+
+        /** In flight, and [accounts]/[categories] have not landed yet. */
+        data object Loading : Status
+
+        /** Accounts and categories are usable; the portfolio sets may still be in flight. */
+        data object Essentials : Status
+        data object Ready : Status
+        data class Failed(val message: String) : Status
+    }
+
+    var accounts by mutableStateOf<List<AccountResponse>>(emptyList())
+        private set
+    var categories by mutableStateOf<List<CategoryResponse>>(emptyList())
+        private set
+    var subPortfolios by mutableStateOf<List<SubPortfolioResponse>>(emptyList())
+        private set
+    var assets by mutableStateOf<List<AssetResponse>>(emptyList())
+        private set
+    var status by mutableStateOf<Status>(Status.Idle)
+        private set
+
+    /**
+     * Accounts and categories have landed at least once for this household.
+     *
+     * Not derived from [status]: a *refresh* that fails (or is still in flight) leaves the
+     * previous answer sitting in [accounts]/[categories], and that answer is still the best one
+     * available. Reading the status instead made a failed refresh hide data the store was still
+     * holding, so Quick Add reopened with the pickers back on "Select…" — the very symptom this
+     * exists to prevent.
+     */
+    var hasEssentials by mutableStateOf(false)
+        private set
+
+    val failureMessage: String? get() = (status as? Status.Failed)?.message
+
+    /**
+     * The household the data above describes. A load for a different one replaces everything
+     * rather than merging — two households' accounts must never mix.
+     */
+    private var loadedHouseholdId: String? = null
+    private var inFlight: Job? = null
+
+    /**
+     * Fetch the reference sets for [householdId], unless they are already loaded (or loading)
+     * for that same household. [force] re-fetches regardless — used after a change is logged,
+     * and by the retry button.
+     */
+    fun load(householdId: String?, force: Boolean = false) {
+        if (householdId == null) {
+            inFlight?.cancel()
+            inFlight = null
+            clear()
+            status = Status.Idle
+            loadedHouseholdId = null
+            return
+        }
+        // Already loaded, or already on its way — either way, don't start a second one.
+        // A previous failure is the exception: there is nothing to wait for there.
+        if (!force && householdId == loadedHouseholdId && status !is Status.Failed) return
+
+        inFlight?.cancel()
+        if (householdId != loadedHouseholdId) clear()
+        loadedHouseholdId = householdId
+        status = Status.Loading
+        inFlight = viewModelScope.launch { fetch(householdId) }
+    }
+
+    private suspend fun fetch(householdId: String) {
+        try {
+            coroutineScope {
+                val accountsReq = async { Api.get<List<AccountResponse>>("/accounts/household/$householdId") }
+                val categoriesReq = async { Api.get<List<CategoryResponse>>("/cashflow/categories/household/$householdId") }
+                val subsReq = async { Api.get<List<SubPortfolioResponse>>("/portfolio/subportfolios/household/$householdId") }
+                val assetsReq = async { Api.get<List<AssetResponse>>("/portfolio/assets") }
+
+                val fetchedAccounts = accountsReq.await()
+                val fetchedCategories = categoriesReq.await()
+                if (loadedHouseholdId != householdId) return@coroutineScope
+                // Published before the portfolio sets are awaited, so the account and category
+                // pickers fill as soon as their own requests land.
+                applyEssentials(fetchedAccounts, fetchedCategories)
+
+                val fetchedSubs = subsReq.await()
+                val fetchedAssets = assetsReq.await()
+                if (loadedHouseholdId != householdId) return@coroutineScope
+                subPortfolios = fetchedSubs
+                assets = fetchedAssets
+                status = Status.Ready
+            }
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            if (loadedHouseholdId != householdId) return
+            // A failure part-way through leaves whatever did land usable rather than blanking
+            // the pickers; the status still says something went wrong.
+            status = Status.Failed(e.message ?: "Couldn't load your accounts.")
+        }
+    }
+
+    /**
+     * Publish the first stage. Kept as its own step rather than inlined so the latch and the
+     * status can't drift apart, and so both are reachable from the tests without a backend.
+     */
+    fun applyEssentials(accounts: List<AccountResponse>, categories: List<CategoryResponse>) {
+        this.accounts = accounts
+        this.categories = categories
+        hasEssentials = true
+        status = Status.Essentials
+    }
+
+    /**
+     * Move the status without touching the data already published — which is the whole point
+     * on a failed refresh.
+     */
+    fun applyStatus(status: Status) {
+        this.status = status
+    }
+
+    private fun clear() {
+        hasEssentials = false
+        accounts = emptyList()
+        categories = emptyList()
+        subPortfolios = emptyList()
+        assets = emptyList()
+    }
+
+    // ---- Local edits --------------------------------------------------------------------
+    //
+    // Quick Add can create a category or an asset from inside the sheet. Folding the new row
+    // in beats re-fetching: the sheet needs it selected immediately, and a round trip is the
+    // thing this exists to avoid.
+
+    fun add(category: CategoryResponse) {
+        if (categories.none { it.id == category.id }) categories = categories + category
+    }
+
+    fun add(asset: AssetResponse) {
+        if (assets.none { it.id == asset.id }) assets = assets + asset
+    }
+}

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/MainScaffold.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/MainScaffold.kt
@@ -17,6 +17,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.ivanlee.financetracker.state.QuickAddViewModel
+import com.ivanlee.financetracker.state.ReferenceDataViewModel
 import com.ivanlee.financetracker.state.SessionViewModel
 import com.ivanlee.financetracker.state.ViewModeViewModel
 import com.ivanlee.financetracker.ui.components.rememberFragmentActivity
@@ -37,6 +38,7 @@ fun MainScaffold(
     sessionVm: SessionViewModel,
     viewModeVm: ViewModeViewModel,
     quickAddVm: QuickAddViewModel,
+    referenceVm: ReferenceDataViewModel,
 ) {
     val navController = rememberNavController()
     val backStackEntry by navController.currentBackStackEntryAsState()
@@ -47,6 +49,21 @@ fun MainScaffold(
     // household changes — it gates the whole Private/Household/Blended switch.
     LaunchedEffect(sessionVm.activeHousehold?.id) {
         viewModeVm.refresh(sessionVm.activeHousehold?.id)
+    }
+
+    // Fill Quick Add's pickers as soon as there's a household to fill them from, rather than
+    // when the sheet opens — the sheet is only composed while presented, so fetching there
+    // meant a round trip on every open and an empty account picker on a cold start (#272).
+    LaunchedEffect(sessionVm.activeHousehold?.id) {
+        referenceVm.load(sessionVm.activeHousehold?.id)
+    }
+
+    // A logged change can create an account or move a balance, so the sheet's next open
+    // should not be working from the pre-change list.
+    LaunchedEffect(quickAddVm.reloadToken) {
+        if (quickAddVm.reloadToken > 0) {
+            referenceVm.load(sessionVm.activeHousehold?.id, force = true)
+        }
     }
 
     // Configure the vault from the user's setting on login / whenever the flag changes, then
@@ -105,6 +122,7 @@ fun MainScaffold(
         ) {
             QuickAddSheet(
                 sessionVm = sessionVm,
+                referenceVm = referenceVm,
                 onDone = {
                     quickAddVm.dismiss()
                     quickAddVm.requestReload()

--- a/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
+++ b/android/app/src/main/java/com/ivanlee/financetracker/ui/quickadd/QuickAddSheet.kt
@@ -8,11 +8,16 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddCircleOutline
+import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -38,14 +43,10 @@ import com.ivanlee.financetracker.data.model.CardLimitStatusRow
 import com.ivanlee.financetracker.data.model.CardStatusResponse
 import com.ivanlee.financetracker.data.model.CardResponse
 import com.ivanlee.financetracker.logic.selectableAccounts
-import com.ivanlee.financetracker.data.model.AccountResponse
-import com.ivanlee.financetracker.data.model.AssetResponse
 import com.ivanlee.financetracker.data.model.BalanceCreate
 import com.ivanlee.financetracker.data.model.BalanceResponse
-import com.ivanlee.financetracker.data.model.CategoryResponse
 import com.ivanlee.financetracker.data.model.DividendCreate
 import com.ivanlee.financetracker.data.model.DividendResponse
-import com.ivanlee.financetracker.data.model.SubPortfolioResponse
 import com.ivanlee.financetracker.data.model.TradeCreate
 import com.ivanlee.financetracker.data.model.TradeResponse
 import com.ivanlee.financetracker.data.model.TradeType
@@ -56,6 +57,7 @@ import com.ivanlee.financetracker.data.model.TransferCreate
 import com.ivanlee.financetracker.data.net.Api
 import com.ivanlee.financetracker.data.net.apiDateOnly
 import com.ivanlee.financetracker.logic.currency
+import com.ivanlee.financetracker.state.ReferenceDataViewModel
 import com.ivanlee.financetracker.state.SessionViewModel
 import com.ivanlee.financetracker.ui.components.DateField
 import com.ivanlee.financetracker.ui.components.DropdownField
@@ -65,8 +67,6 @@ import com.ivanlee.financetracker.ui.components.SegmentedChoice
 import com.ivanlee.financetracker.ui.components.SwitchRow
 import com.ivanlee.financetracker.ui.transactions.CategoryEditDialog
 import com.ivanlee.financetracker.ui.portfolio.AssetCreateDialog
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import java.time.Instant
 
@@ -89,17 +89,19 @@ enum class QuickAddMode(val label: String) {
 @Composable
 fun QuickAddSheet(
     sessionVm: SessionViewModel,
+    referenceVm: ReferenceDataViewModel,
     onDone: () -> Unit,
 ) {
     val household = sessionVm.activeHousehold
     val baseCurrency = household?.baseCurrency ?: "USD"
     val scope = rememberCoroutineScope()
 
-    var accounts by remember { mutableStateOf<List<AccountResponse>>(emptyList()) }
-    var categories by remember { mutableStateOf<List<CategoryResponse>>(emptyList()) }
-    var subPortfolios by remember { mutableStateOf<List<SubPortfolioResponse>>(emptyList()) }
-    var assets by remember { mutableStateOf<List<AssetResponse>>(emptyList()) }
-    var loaded by remember { mutableStateOf(false) }
+    // Reference data, loaded once per household at the app root rather than on every open —
+    // see ReferenceDataViewModel and #272.
+    val accounts = referenceVm.accounts
+    val categories = referenceVm.categories
+    val subPortfolios = referenceVm.subPortfolios
+    val assets = referenceVm.assets
 
     var mode by remember { mutableStateOf(QuickAddMode.EXPENSE) }
     var amountText by remember { mutableStateOf("") }
@@ -164,45 +166,41 @@ fun QuickAddSheet(
         QuickAddMode.BALANCE -> amount != null && accountId != null
     }
 
-    LaunchedEffect(household?.id) {
-        if (loaded || household == null) return@LaunchedEffect
-        try {
-            coroutineScope {
-                val a = async { Api.get<List<AccountResponse>>("/accounts/household/${household.id}") }
-                val c = async { Api.get<List<CategoryResponse>>("/cashflow/categories/household/${household.id}") }
-                val s = async { Api.get<List<SubPortfolioResponse>>("/portfolio/subportfolios/household/${household.id}") }
-                val t = async { Api.get<List<AssetResponse>>("/portfolio/assets") }
-                accounts = a.await(); categories = c.await(); subPortfolios = s.await(); assets = t.await()
+    // Normally a no-op: the app root loaded this when the household resolved. It still
+    // matters on the two paths that leave it unloaded — a household that changed while the
+    // sheet was closed, and a load that failed, which this retries on open.
+    LaunchedEffect(household?.id) { referenceVm.load(household?.id) }
+
+    // Defaults mirror the web/iOS quick-add routing: the household's configured funding
+    // account and sub-portfolio, except expense/income, which start from the user's own
+    // default expense account when one is set.
+    //
+    // Keyed on the store's status so the two stages each get a pass — the account defaults
+    // land with `Essentials`, the sub-portfolio and asset ones with `Ready`. Every assignment
+    // is guarded on the field still being null, so re-running is harmless and a pick the user
+    // has already made is never overwritten.
+    LaunchedEffect(referenceVm.status) {
+        if (household == null || !referenceVm.hasEssentials) return@LaunchedEffect
+        val loadedAccounts = referenceVm.accounts
+        val funding = loadedAccounts.firstOrNull { it.id == household.defaultFundingAccountId }
+            ?: loadedAccounts.firstOrNull()
+        val expenseDefault =
+            loadedAccounts.firstOrNull { it.id == sessionVm.user?.defaultAccountId } ?: funding
+        if (accountId == null) {
+            accountId = if (mode == QuickAddMode.EXPENSE || mode == QuickAddMode.INCOME) {
+                expenseDefault?.id
+            } else {
+                funding?.id
             }
-            loaded = true
-            // Defaults mirror the web/mobile quick-add routing: the household's configured
-            // funding account and sub-portfolio, except expense/income, which start from the
-            // user's own default expense account when one is set.
-            //
-            // These read the freshly-awaited lists, NOT the derived `tradableAssets` /
-            // `filteredCategories` above — those were captured when the effect launched, i.e.
-            // while everything was still empty, so seeding from them silently did nothing.
-            val loadedAccounts = accounts
-            val funding = loadedAccounts.firstOrNull { it.id == household.defaultFundingAccountId }
-                ?: loadedAccounts.firstOrNull()
-            val expenseDefault =
-                loadedAccounts.firstOrNull { it.id == sessionVm.user?.defaultAccountId } ?: funding
-            if (accountId == null) {
-                accountId = if (mode == QuickAddMode.EXPENSE || mode == QuickAddMode.INCOME) {
-                    expenseDefault?.id
-                } else {
-                    funding?.id
-                }
-            }
-            if (fromAccountId == null) fromAccountId = funding?.id
-            if (toAccountId == null) toAccountId = loadedAccounts.firstOrNull { it.id != fromAccountId }?.id
-            if (subPortfolioId == null) {
-                subPortfolioId = (subPortfolios.firstOrNull { it.id == household.defaultSubPortfolioId }
-                    ?: subPortfolios.firstOrNull())?.id
-            }
-            if (assetId == null) assetId = assets.filter { !it.isCash }.minByOrNull { it.ticker }?.id
-        } catch (e: Exception) {
-            error = e.message
+        }
+        if (fromAccountId == null) fromAccountId = funding?.id
+        if (toAccountId == null) toAccountId = loadedAccounts.firstOrNull { it.id != fromAccountId }?.id
+        if (subPortfolioId == null) {
+            subPortfolioId = (referenceVm.subPortfolios.firstOrNull { it.id == household.defaultSubPortfolioId }
+                ?: referenceVm.subPortfolios.firstOrNull())?.id
+        }
+        if (assetId == null) {
+            assetId = referenceVm.assets.filter { !it.isCash }.minByOrNull { it.ticker }?.id
         }
     }
 
@@ -321,6 +319,43 @@ fun QuickAddSheet(
         }
 
         HorizontalDivider()
+
+        // Says which of the three states the pickers are in — still loading, failed, or
+        // genuinely empty — instead of leaving every picker on a bare "Select…", which reads
+        // as "this household has no accounts" (#272).
+        val referenceFailure = referenceVm.failureMessage
+        when {
+            referenceFailure != null -> Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(
+                    referenceFailure,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                )
+                TextButton(onClick = { referenceVm.load(household?.id, force = true) }) {
+                    Icon(Icons.Filled.Refresh, contentDescription = null)
+                    Spacer(Modifier.width(8.dp))
+                    Text("Retry")
+                }
+            }
+
+            !referenceVm.hasEssentials -> Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+            ) {
+                CircularProgressIndicator(Modifier.size(18.dp), strokeWidth = 2.dp)
+                Text(
+                    "Loading your accounts…",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+
+            selectableAccounts(accounts).isEmpty() -> Text(
+                "No accounts yet — add one from the Accounts tab first.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
 
         when (mode) {
             QuickAddMode.EXPENSE, QuickAddMode.INCOME -> {
@@ -522,7 +557,7 @@ fun QuickAddSheet(
             lockedType = if (mode == QuickAddMode.INCOME) TransactionType.INCOME else TransactionType.EXPENSE,
             onDismiss = { showNewCategory = false },
             onSaved = { created ->
-                categories = categories + created
+                referenceVm.add(created)
                 categoryId = created.id
             },
         )
@@ -533,7 +568,7 @@ fun QuickAddSheet(
             defaultCurrency = selectedAsset?.currency ?: accounts.firstOrNull()?.currency ?: baseCurrency,
             onDismiss = { showNewAsset = false },
             onCreated = { created ->
-                assets = assets + created
+                referenceVm.add(created)
                 assetId = created.id
             },
         )

--- a/android/app/src/test/java/com/ivanlee/financetracker/ReferenceDataViewModelTest.kt
+++ b/android/app/src/test/java/com/ivanlee/financetracker/ReferenceDataViewModelTest.kt
@@ -1,0 +1,100 @@
+package com.ivanlee.financetracker
+
+import com.ivanlee.financetracker.data.model.AssetResponse
+import com.ivanlee.financetracker.data.model.CategoryResponse
+import com.ivanlee.financetracker.data.model.TransactionType
+import com.ivanlee.financetracker.state.ReferenceDataViewModel
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Kotlin twin of iOS's `ReferenceDataStoreTests`.
+ *
+ * `ReferenceDataViewModel` is what stops Quick Add opening with an empty account picker on a
+ * cold start (#272). Its fetching half needs a backend and isn't exercised here; what is
+ * exercised is the part that decides whether the pickers have something to show and how a
+ * locally-created row folds in — the two places the empty-picker bug can come back.
+ */
+class ReferenceDataViewModelTest {
+
+    private fun category(id: String, name: String = "Dining") =
+        CategoryResponse(id = id, householdId = "hh", name = name, type = TransactionType.EXPENSE)
+
+    private fun asset(id: String, ticker: String = "VOO") =
+        AssetResponse(id = id, ticker = ticker, name = ticker, type = "stock", currency = "USD")
+
+    // ---- hasEssentials ------------------------------------------------------------------
+
+    @Test
+    fun `starts with nothing to show`() {
+        val vm = ReferenceDataViewModel()
+        assertEquals(ReferenceDataViewModel.Status.Idle, vm.status)
+        assertFalse(vm.hasEssentials)
+        assertNull(vm.failureMessage)
+    }
+
+    /** No household means nothing to load — and that is Idle, not a failure, so the sheet shows
+     *  neither a spinner nor an error. */
+    @Test
+    fun `no household clears to idle`() {
+        val vm = ReferenceDataViewModel()
+        vm.applyEssentials(emptyList(), listOf(category("c1")))
+        vm.load(null)
+        assertEquals(ReferenceDataViewModel.Status.Idle, vm.status)
+        assertTrue(vm.accounts.isEmpty())
+        assertTrue(vm.categories.isEmpty())
+        assertFalse(vm.hasEssentials)
+    }
+
+    // ---- failure reporting --------------------------------------------------------------
+
+    @Test
+    fun `failure exposes its message`() {
+        val vm = ReferenceDataViewModel()
+        vm.applyStatus(ReferenceDataViewModel.Status.Failed("Could not connect to the server."))
+        assertEquals("Could not connect to the server.", vm.failureMessage)
+    }
+
+    /**
+     * The regression this exists to prevent, in miniature: a *refresh* that fails must not take
+     * the previously-loaded pickers down with it. `hasEssentials` therefore records that
+     * accounts and categories have arrived, rather than being read back off the current status.
+     */
+    @Test
+    fun `failed refresh keeps what already landed`() {
+        val vm = ReferenceDataViewModel()
+        vm.applyEssentials(emptyList(), listOf(category("c1")))
+        assertTrue(vm.hasEssentials)
+        vm.applyStatus(ReferenceDataViewModel.Status.Failed("offline"))
+        assertTrue(vm.hasEssentials)
+        assertEquals(1, vm.categories.size)
+    }
+
+    // ---- local edits --------------------------------------------------------------------
+
+    @Test
+    fun `adds a category created in the sheet`() {
+        val vm = ReferenceDataViewModel()
+        vm.add(category("c1"))
+        assertEquals(listOf("c1"), vm.categories.map { it.id })
+    }
+
+    /**
+     * Quick Add folds a newly-created row in *and* the next refresh returns it from the server,
+     * so adding the same id twice must not double it up in the picker.
+     */
+    @Test
+    fun `does not duplicate an existing row`() {
+        val vm = ReferenceDataViewModel()
+        vm.add(category("c1"))
+        vm.add(category("c1", name = "Dining (renamed)"))
+        assertEquals(1, vm.categories.size)
+
+        vm.add(asset("a1"))
+        vm.add(asset("a1"))
+        assertEquals(1, vm.assets.size)
+    }
+}

--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -85,7 +85,28 @@ When constructing pages, follow these approved layouts:
   follows the references, preceded by `react-router typegen` so generated route module types
   exist if a loader ever imports them. It exits non-zero on error, so it is safe in CI.
 - **The repo is not type-clean, so judge by the delta, not the total.** `dev` currently has
-  38 errors. A change is fine if it adds none of its own; "all green" is not achievable yet
-  and waiting for it just means never typechecking.
+  35 errors (it said 38 until this was re-measured on 2026-09-10). A change is fine if it
+  adds none of its own; "all green" is not achievable yet and waiting for it just means never
+  typechecking.
+- **The ⌘K command bar's reference data comes from `lib/ReferenceDataContext.tsx`, not from a
+  fetch on open.** The bar used to fire four requests from an effect gated on `isOpen`, so the
+  first ⌘K after a page load had no accounts to parse against for a full round trip — typing
+  "12.34 lunch chase" resolved no account and the resting view showed no recents, which is
+  indistinguishable from a household with nothing in it (#272; the same bug was reported on iOS
+  and fixed on all three clients). The provider sits at the root beside `CommandBarProvider`,
+  loads when the active household resolves, and is re-loaded by `reload()` after a command is
+  logged or undone — route revalidation does not cover it. Four rules it encodes, shared with
+  `ios/.../ReferenceDataStore.swift` and `android/.../ReferenceDataViewModel.kt`:
+    - **Accounts and categories are published before the other two are awaited**
+      (`essentials` → `ready`). Parsing a command needs only those.
+    - **`hasEssentials` is a latch, not a reading of `status`.** A refresh that fails leaves the
+      previous answer in place and it is still the best one available.
+    - **`idle` (no household) is not `loading`.** The bar is mounted at the root, so it renders
+      for a logged-out visitor and mid-onboarding; showing "Loading your accounts…" there would
+      be a promise that never resolves. The banner is gated on `loading && !hasEssentials`, so a
+      refresh over data we already have stays silent too.
+    - **The transaction request is capped** (`?limit=`). The bar displays three; without a limit
+      this pulled the household's entire history to show them, and it is by far the heaviest of
+      the four.
 - **Check Schemas:** Always verify the Pydantic schemas in `backend/src/schemas.py` before binding API data to the frontend state.
 - **Aesthetics Matter:** The design must WOW the user. Ensure smooth hover effects, micro-animations, glassmorphism (if applicable), and flawless 4pt alignment. A basic MVP-looking UI is unacceptable.

--- a/frontend/src/components/CommandBar/CommandBar.tsx
+++ b/frontend/src/components/CommandBar/CommandBar.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo} from "react";
 import { useNavigate, useRevalidator, useFetcher } from "react-router";
 import { useCommandBar } from "../../lib/CommandBarContext";
+import { useReferenceData } from "../../lib/ReferenceDataContext";
 import { useHousehold } from "../../lib/HouseholdContext";
 import { useAuth } from "../../lib/AuthContext";
 import { useViewMode } from "../../lib/ViewModeContext";
@@ -25,7 +26,7 @@ import {
     TradeView,
     TransferView,
 } from "./CommandBarViews";
-import type { AccountResponse, SubPortfolioResponse, TransactionResponse, CategoryResponse, AssetResponse } from "../../types/types";
+import type { AccountResponse, AssetResponse } from "../../types/types";
 import type { CardPickerData } from "../../pages/Transactions/cardCategories.resource";
 import { cardCategoryPickerOptions } from "../../lib/cards";
 
@@ -35,6 +36,20 @@ export function CommandBar() {
     const { activeHousehold } = useHousehold();
     const { user } = useAuth();
     const { hasHousehold } = useViewMode();
+    // Reference data, loaded once per household at the app root rather than on every open —
+    // see `ReferenceDataContext` and #272.
+    const {
+        accounts,
+        categories,
+        subportfolios,
+        recent,
+        status: referenceStatus,
+        hasEssentials,
+        failureMessage: referenceFailure,
+        reload: reloadReference,
+        addCategory,
+        addAccount,
+    } = useReferenceData();
     const revalidator = useRevalidator();
     const navigate = useNavigate();
 
@@ -54,10 +69,6 @@ export function CommandBar() {
     const [submitting, setSubmitting] = useState(false);
     const [undoData, setUndoData] = useState<{ path: string } | null>(null);
 
-    const [accounts, setAccounts] = useState<AccountResponse[]>([]);
-    const [subportfolios, setSubportfolios] = useState<SubPortfolioResponse[]>([]);
-    const [categories, setCategories] = useState<CategoryResponse[]>([]);
-    const [recent, setRecent] = useState<TransactionResponse[]>([]);
     const [assetSuggestions, setAssetSuggestions] = useState<AssetResponse[]>([]);
     const [livePrice, setLivePrice] = useState<{ ticker: string; price: number; currency: string } | null>(null);
     const [priceLoading, setPriceLoading] = useState(false);
@@ -82,16 +93,9 @@ export function CommandBar() {
         setLivePrice(null);
         setHighlightIndex(0);
         requestAnimationFrame(() => inputRef.current?.focus());
-
-        if (activeHousehold) {
-            api.get(`/accounts/household/${activeHousehold.id}`).then(r => setAccounts(r.data)).catch(() => setAccounts([]));
-            api.get(`/portfolio/subportfolios/household/${activeHousehold.id}`).then(r => setSubportfolios(r.data)).catch(() => setSubportfolios([]));
-            api.get(`/cashflow/categories/household/${activeHousehold.id}`).then(r => setCategories(r.data)).catch(() => setCategories([]));
-            api.get(`/cashflow/transactions/household/${activeHousehold.id}`).then(r => {
-                const sorted = [...r.data].sort((a: TransactionResponse, b: TransactionResponse) => (a.date < b.date ? 1 : -1));
-                setRecent(sorted.slice(0, 3));
-            }).catch(() => setRecent([]));
-        }
+        // No fetch here. The reference data is already loaded (or on its way) from the app
+        // root, which is the whole point — opening the bar used to start four requests and
+        // leave the parser with no accounts to match against until they landed.
     }, [isOpen, activeHousehold?.id]);
 
     useEffect(() => () => {
@@ -113,6 +117,10 @@ export function CommandBar() {
         window.addEventListener("keydown", onKey);
         return () => window.removeEventListener("keydown", onKey);
     }, [isOpen, handleClose]);
+
+    // The resting and search views show the three newest, as they always have; the context
+    // holds more so a later consumer isn't forced back to a per-open fetch.
+    const recentThree = useMemo(() => recent.slice(0, 3), [recent]);
 
     const parsed: ParsedCommand = scanResult ? { type: "expense", amount: scanResult.amount, merchant: scanResult.merchant, category: scanResult.category, account: accounts[0] || null } : parseCommand(query, accounts);
     const activeTicker = parsed.type === "trade" || parsed.type === "dividend" ? parsed.ticker : null;
@@ -296,7 +304,7 @@ export function CommandBar() {
         if (existing) return existing.id;
         try {
             const res = await api.post("/cashflow/categories", { household_id: activeHousehold.id, name, type });
-            setCategories(prev => [...prev, res.data]);
+            addCategory(res.data);
             return res.data.id;
         } catch {
             return null;
@@ -311,6 +319,9 @@ export function CommandBar() {
         setUndoData(undo);
         setPhase("success");
         revalidator.revalidate();
+        // Route loaders don't cover the bar's own reference data, and the next open reads it
+        // straight from the context rather than re-fetching.
+        reloadReference();
         successTimer.current = setTimeout(() => {
             handleClose();
         }, 1800);
@@ -320,6 +331,7 @@ export function CommandBar() {
         if (undoData) {
             try { await api.delete(undoData.path); } catch { /* best effort */ }
             revalidator.revalidate();
+            reloadReference();
         }
         handleClose();
     };
@@ -361,7 +373,7 @@ export function CommandBar() {
                         owner_user_id: null,
                     });
                     account = created.data;
-                    setAccounts(prev => [...prev, account!]);
+                    addAccount(account);
                 }
                 const res = await api.post("/accounts/balances", {
                     account_id: account.id,
@@ -521,6 +533,29 @@ export function CommandBar() {
                     </button>
                 </div>
 
+                {/* Says which of the two unhappy states the bar is in rather than silently
+                    parsing against an empty account list — a command bar that can't resolve
+                    "chase" looks broken, and looks identical to a household with no accounts
+                    (#272). Nothing renders once the data is there, which is the common case,
+                    nor when there is no household at all (`idle`), where "loading" would be a
+                    lie that never resolves. A refresh over data we already have stays silent
+                    too — the bar is fully usable, so saying so would only be noise. */}
+                {referenceFailure ? (
+                    <div className="flex items-center justify-between gap-3 border-b border-base-200 px-4 py-2.5 text-xs dark:border-base-800">
+                        <span className="text-red-500">{referenceFailure}</span>
+                        <button
+                            onClick={reloadReference}
+                            className="shrink-0 font-semibold text-primary-500 hover:underline"
+                        >
+                            Retry
+                        </button>
+                    </div>
+                ) : referenceStatus.kind === "loading" && !hasEssentials ? (
+                    <div className="border-b border-base-200 px-4 py-2.5 text-xs text-base-400 dark:border-base-800">
+                        Loading your accounts…
+                    </div>
+                ) : null}
+
                 {/* Body */}
                 <div className="max-h-[420px] overflow-y-auto">
                     {phase === "scanning" && <ScanView pct={scanPct} />}
@@ -536,7 +571,7 @@ export function CommandBar() {
                     )}
 
                     {phase !== "scanning" && phase !== "success" && parsed.type === "empty" && (
-                        <RestingView recent={recent} accounts={accounts} onDemo={runDemo} />
+                        <RestingView recent={recentThree} accounts={accounts} onDemo={runDemo} />
                     )}
 
                     {phase !== "scanning" && phase !== "success" && parsed.type === "expense" && (
@@ -602,7 +637,7 @@ export function CommandBar() {
                     )}
 
                     {phase !== "scanning" && phase !== "success" && parsed.type === "search" && (
-                        <SearchView term={parsed.term} subportfolios={subportfolios} recent={recent} onSelectGoal={(id) => goToSearchResult(`/goals/${id}`)} onSelectTxn={() => goToSearchResult("/transactions")} />
+                        <SearchView term={parsed.term} subportfolios={subportfolios} recent={recentThree} onSelectGoal={(id) => goToSearchResult(`/goals/${id}`)} onSelectTxn={() => goToSearchResult("/transactions")} />
                     )}
                 </div>
 

--- a/frontend/src/lib/ReferenceDataContext.test.tsx
+++ b/frontend/src/lib/ReferenceDataContext.test.tsx
@@ -1,0 +1,118 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { ReferenceDataProvider, useReferenceData } from "./ReferenceDataContext";
+import api from "./api";
+import type { HouseholdResponse } from "../types/types";
+
+// The provider reads only `activeHousehold`; mocking the hook keeps the household context's
+// own surface unchanged (it deliberately doesn't export its context object).
+const activeHousehold = { current: null as HouseholdResponse | null };
+vi.mock("./HouseholdContext", () => ({
+    useHousehold: () => ({ activeHousehold: activeHousehold.current }),
+}));
+
+/**
+ * The command bar's reference data (`ReferenceDataContext`) is what stops ⌘K opening with no
+ * accounts to parse against on a cold page load (#272). The twin of iOS's
+ * `ReferenceDataStoreTests` and Android's `ReferenceDataViewModelTest`, minus the parts that
+ * only make sense with a real backend.
+ */
+
+const household = { id: "hh-1", name: "Test", base_currency: "SGD" } as unknown as HouseholdResponse;
+
+function Probe() {
+    const { accounts, categories, subportfolios, recent, status, hasEssentials, failureMessage, reload } =
+        useReferenceData();
+    return (
+        <div>
+            <span data-testid="status">{status.kind}</span>
+            <span data-testid="essentials">{String(hasEssentials)}</span>
+            <span data-testid="failure">{failureMessage ?? ""}</span>
+            <span data-testid="counts">
+                {accounts.length}/{categories.length}/{subportfolios.length}/{recent.length}
+            </span>
+            <button onClick={reload}>reload</button>
+        </div>
+    );
+}
+
+function renderWithHousehold(active: HouseholdResponse | null) {
+    activeHousehold.current = active;
+    return render(
+        <ReferenceDataProvider>
+            <Probe />
+        </ReferenceDataProvider>,
+    );
+}
+
+/** Resolve each endpoint independently so the two stages can be observed apart. */
+function stubApi(overrides: Record<string, unknown[]> = {}) {
+    return vi.spyOn(api, "get").mockImplementation((url: string) => {
+        const key = url.includes("/accounts/household") ? "accounts"
+            : url.includes("/cashflow/categories") ? "categories"
+                : url.includes("/portfolio/subportfolios") ? "subportfolios"
+                    : "recent";
+        return Promise.resolve({ data: overrides[key] ?? [] }) as never;
+    });
+}
+
+describe("ReferenceDataContext", () => {
+    afterEach(() => vi.restoreAllMocks());
+    beforeEach(() => vi.clearAllMocks());
+
+    it("has nothing to show, and is idle rather than failed, with no household", async () => {
+        const get = stubApi();
+        renderWithHousehold(null);
+        expect(screen.getByTestId("status").textContent).toBe("idle");
+        expect(screen.getByTestId("essentials").textContent).toBe("false");
+        expect(get).not.toHaveBeenCalled();
+    });
+
+    it("loads once the household resolves, accounts and categories first", async () => {
+        stubApi({
+            accounts: [{ id: "a1" }],
+            categories: [{ id: "c1" }],
+            subportfolios: [{ id: "s1" }],
+            recent: [{ id: "t1", date: "2026-01-01" }],
+        });
+        renderWithHousehold(household);
+        await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("ready"));
+        expect(screen.getByTestId("counts").textContent).toBe("1/1/1/1");
+        expect(screen.getByTestId("essentials").textContent).toBe("true");
+    });
+
+    /** The bar shows three; asking for more than that is deliberate headroom, but asking for
+     *  the household's *entire* history to display three was the old behaviour and by far the
+     *  heaviest of the four requests. */
+    it("caps the transaction request instead of pulling the whole history", async () => {
+        const get = stubApi();
+        renderWithHousehold(household);
+        await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("ready"));
+        const transactionCall = get.mock.calls
+            .map(c => String(c[0]))
+            .find(u => u.includes("/cashflow/transactions/household"));
+        expect(transactionCall).toContain("limit=");
+    });
+
+    /**
+     * The regression this exists to prevent, in miniature: a *refresh* that fails must not take
+     * the already-loaded pickers down with it. `hasEssentials` therefore latches rather than
+     * being read back off the current status.
+     */
+    it("keeps what already landed when a refresh fails", async () => {
+        const get = stubApi({ accounts: [{ id: "a1" }], categories: [{ id: "c1" }] });
+        renderWithHousehold(household);
+        await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("ready"));
+
+        get.mockImplementation(() => Promise.reject(new Error("Network Error")) as never);
+        await act(async () => {
+            screen.getByText("reload").click();
+        });
+
+        await waitFor(() => expect(screen.getByTestId("status").textContent).toBe("failed"));
+        expect(screen.getByTestId("failure").textContent).toBe("Network Error");
+        // Still usable — this is the whole point.
+        expect(screen.getByTestId("essentials").textContent).toBe("true");
+        expect(screen.getByTestId("counts").textContent).toBe("1/1/0/0");
+    });
+});

--- a/frontend/src/lib/ReferenceDataContext.tsx
+++ b/frontend/src/lib/ReferenceDataContext.tsx
@@ -1,0 +1,177 @@
+import { createContext, useCallback, useContext, useEffect, useRef, useState, type ReactNode } from "react";
+import api from "./api";
+import { useHousehold } from "./HouseholdContext";
+import type {
+    AccountResponse,
+    CategoryResponse,
+    SubPortfolioResponse,
+    TransactionResponse,
+} from "../types/types";
+
+/**
+ * The reference sets the ⌘K command bar works from — accounts, categories, sub-portfolios and
+ * the few recent transactions it shows — loaded once per household at the app root instead of
+ * every time the bar opens. Mirrors `ios/.../State/ReferenceDataStore.swift` and
+ * `android/.../state/ReferenceDataViewModel.kt`.
+ *
+ * The bar used to fire all four requests from an effect gated on `isOpen`. On a cold page load
+ * the first ⌘K therefore had no accounts to parse against for a full round trip, so typing
+ * "12.34 lunch chase" resolved no account and the resting view showed no recents —
+ * indistinguishable from a household with nothing in it (#272; the same bug was reported on
+ * iOS and fixed there and on Android). Loading when the household resolves means the bar is
+ * usable the instant it opens.
+ *
+ * Accounts and categories are published **before** the other two are awaited: parsing a
+ * command needs only those, and making it wait on the transaction list buys it nothing.
+ */
+
+export type ReferenceStatus =
+    | { kind: "idle" }
+    | { kind: "loading" }
+    /** Accounts and categories are usable; the rest may still be in flight. */
+    | { kind: "essentials" }
+    | { kind: "ready" }
+    | { kind: "failed"; message: string };
+
+interface ReferenceDataContextType {
+    accounts: AccountResponse[];
+    categories: CategoryResponse[];
+    subportfolios: SubPortfolioResponse[];
+    recent: TransactionResponse[];
+    status: ReferenceStatus;
+    /**
+     * Accounts and categories have landed at least once for this household.
+     *
+     * Not derived from `status`: a *refresh* that fails (or is still in flight) leaves the
+     * previous answer in place, and that answer is still the best one available. Reading the
+     * status instead would make a failed refresh hide data we are still holding — the very
+     * symptom this exists to prevent.
+     */
+    hasEssentials: boolean;
+    failureMessage: string | null;
+    /** Re-fetch regardless of what is already loaded — after a command is logged, or on retry. */
+    reload: () => void;
+    /** Fold a category created from inside the bar in, rather than re-fetching for one row. */
+    addCategory: (category: CategoryResponse) => void;
+    /** Same, for an account created inline. */
+    addAccount: (account: AccountResponse) => void;
+}
+
+const ReferenceDataContext = createContext<ReferenceDataContextType>({
+    accounts: [],
+    categories: [],
+    subportfolios: [],
+    recent: [],
+    status: { kind: "idle" },
+    hasEssentials: false,
+    failureMessage: null,
+    reload: () => { },
+    addCategory: () => { },
+    addAccount: () => { },
+});
+
+/** How many transactions to ask for. The bar shows three; without a limit this request
+ *  downloaded the household's entire history to display them, which on a multi-year household
+ *  is by far the heaviest of the four. */
+const RECENT_LIMIT = 50;
+
+export const ReferenceDataProvider = ({ children }: { children: ReactNode }) => {
+    const { activeHousehold } = useHousehold();
+    const householdId = activeHousehold?.id ?? null;
+
+    const [accounts, setAccounts] = useState<AccountResponse[]>([]);
+    const [categories, setCategories] = useState<CategoryResponse[]>([]);
+    const [subportfolios, setSubportfolios] = useState<SubPortfolioResponse[]>([]);
+    const [recent, setRecent] = useState<TransactionResponse[]>([]);
+    const [status, setStatus] = useState<ReferenceStatus>({ kind: "idle" });
+    const [hasEssentials, setHasEssentials] = useState(false);
+
+    /** Bumped to force a re-fetch; also the token a late response checks itself against, so a
+     *  slow first load can't overwrite a newer one. */
+    const [reloadToken, setReloadToken] = useState(0);
+    const runIdRef = useRef(0);
+
+    const reload = useCallback(() => setReloadToken(t => t + 1), []);
+
+    useEffect(() => {
+        if (!householdId) {
+            setAccounts([]);
+            setCategories([]);
+            setSubportfolios([]);
+            setRecent([]);
+            setHasEssentials(false);
+            setStatus({ kind: "idle" });
+            return;
+        }
+
+        const runId = ++runIdRef.current;
+        const current = () => runIdRef.current === runId;
+        setStatus({ kind: "loading" });
+
+        (async () => {
+            try {
+                const [accountsRes, categoriesRes] = await Promise.all([
+                    api.get<AccountResponse[]>(`/accounts/household/${householdId}`),
+                    api.get<CategoryResponse[]>(`/cashflow/categories/household/${householdId}`),
+                ]);
+                if (!current()) return;
+                setAccounts(accountsRes.data);
+                setCategories(categoriesRes.data);
+                setHasEssentials(true);
+                setStatus({ kind: "essentials" });
+
+                const [subsRes, recentRes] = await Promise.all([
+                    api.get<SubPortfolioResponse[]>(`/portfolio/subportfolios/household/${householdId}`),
+                    api.get<TransactionResponse[]>(
+                        `/cashflow/transactions/household/${householdId}?limit=${RECENT_LIMIT}`,
+                    ),
+                ]);
+                if (!current()) return;
+                setSubportfolios(subsRes.data);
+                setRecent([...recentRes.data].sort((a, b) => (a.date < b.date ? 1 : -1)));
+                setStatus({ kind: "ready" });
+            } catch (e) {
+                if (!current()) return;
+                // A failure part-way through leaves whatever did land usable rather than
+                // blanking it; the status still says something went wrong.
+                const message = e instanceof Error ? e.message : "Couldn't load your accounts.";
+                setStatus({ kind: "failed", message });
+            }
+        })();
+        // The household changing replaces everything (two households' accounts must never
+        // mix); `reloadToken` re-runs it for the same household.
+    }, [householdId, reloadToken]);
+
+    const addCategory = useCallback((category: CategoryResponse) => {
+        setCategories(existing =>
+            existing.some(c => c.id === category.id) ? existing : [...existing, category],
+        );
+    }, []);
+
+    const addAccount = useCallback((account: AccountResponse) => {
+        setAccounts(existing =>
+            existing.some(a => a.id === account.id) ? existing : [...existing, account],
+        );
+    }, []);
+
+    return (
+        <ReferenceDataContext.Provider
+            value={{
+                accounts,
+                categories,
+                subportfolios,
+                recent,
+                status,
+                hasEssentials,
+                failureMessage: status.kind === "failed" ? status.message : null,
+                reload,
+                addCategory,
+                addAccount,
+            }}
+        >
+            {children}
+        </ReferenceDataContext.Provider>
+    );
+};
+
+export const useReferenceData = () => useContext(ReferenceDataContext);

--- a/frontend/src/root.tsx
+++ b/frontend/src/root.tsx
@@ -14,6 +14,7 @@ import { ThemeProvider } from "./lib/ThemeContext";
 import { HouseholdProvider } from "./lib/HouseholdContext";
 import { ViewModeProvider } from "./lib/ViewModeContext";
 import { CommandBarProvider } from "./lib/CommandBarContext";
+import { ReferenceDataProvider } from "./lib/ReferenceDataContext";
 import Sidebar, { MobileNav } from "./components/sidebar";
 import { CommandBar } from "./components/CommandBar/CommandBar";
 import { QuickAddButton } from "./components/QuickAddButton";
@@ -93,21 +94,23 @@ export function Layout({
                     <ThemeProvider>
                         <HouseholdProvider initialHouseholds={households}>
                             <ViewModeProvider>
-                                <CommandBarProvider>
-                                    <div className="flex h-dvh overflow-hidden bg-base-100 text-base-900 dark:bg-base-950 dark:text-base-50 transition-colors duration-300 print:block print:h-auto print:overflow-visible print:bg-white">
-                                        <Sidebar />
-                                        {/* min-w-0 lets this column shrink below its content's intrinsic
-                                            width — without it a wide table pushes the whole shell sideways. */}
-                                        <div className="flex min-w-0 flex-1 flex-col print:block">
-                                            <MobileNav />
-                                            <main className="min-w-0 flex-1 overflow-y-auto bg-base-50 dark:bg-base-900 transition-colors duration-300 print:overflow-visible print:bg-white">
-                                                {children}
-                                            </main>
+                                <ReferenceDataProvider>
+                                    <CommandBarProvider>
+                                        <div className="flex h-dvh overflow-hidden bg-base-100 text-base-900 dark:bg-base-950 dark:text-base-50 transition-colors duration-300 print:block print:h-auto print:overflow-visible print:bg-white">
+                                            <Sidebar />
+                                            {/* min-w-0 lets this column shrink below its content's intrinsic
+                                                width — without it a wide table pushes the whole shell sideways. */}
+                                            <div className="flex min-w-0 flex-1 flex-col print:block">
+                                                <MobileNav />
+                                                <main className="min-w-0 flex-1 overflow-y-auto bg-base-50 dark:bg-base-900 transition-colors duration-300 print:overflow-visible print:bg-white">
+                                                    {children}
+                                                </main>
+                                            </div>
                                         </div>
-                                    </div>
-                                    <QuickAddButton />
-                                    <CommandBar />
-                                </CommandBarProvider>
+                                        <QuickAddButton />
+                                        <CommandBar />
+                                    </CommandBarProvider>
+                                </ReferenceDataProvider>
                             </ViewModeProvider>
                         </HouseholdProvider>
                     </ThemeProvider>

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -16,6 +16,9 @@ FinanceTracker/
   Networking/APIClient.swift # actor; Bearer auth, 401 → /auth/refresh retry (mirrors mobile/src/lib/api.ts)
   Networking/Keychain.swift  # token storage
   State/SessionStore.swift   # @Observable: user, households, activeHousehold (mirrors mobile AuthContext + HouseholdContext)
+  State/ReferenceDataStore.swift # @Observable: the accounts/categories/sub-portfolios/assets/
+                             #   counterparties Quick Add fills its pickers from, loaded once per
+                             #   household at the app root — see the Quick Add note in Conventions
   Support/Formatters.swift   # currency/percent/date formatting helpers
   Support/GoalProjection.swift # Swift port of web lib/goals.ts (projectGoal / valueHistory) — keep in sync
   Support/HistoryGroups.swift # Swift port of web lib/historyGroups.ts — day/month/year bucketing
@@ -226,8 +229,33 @@ FinanceTracker/
       default account / category / sub-portfolio in `applyDefaults()` *after* a fetch.
       Snapshotting "the values as first drawn" caught both mid-setup and read their own seeding
       as a user edit, so a brand-new account sheet asked "Discard changes?" before it had been
-      touched. Those two pass `settled:` (`didSeedPrivacy && !currency.isEmpty`, and `loaded`);
+      touched. Those two pass `settled:` (`didSeedPrivacy && !currency.isEmpty`, and — since
+      the Quick Add reference data moved to `ReferenceDataStore` — `appliedDefaults`);
       the baseline is taken when it turns true. Any new form that seeds itself must do the same.
+      **Settle on your own "I have finished seeding" flag, not on the state the seeding reacts
+      to.** `QuickAddView` briefly settled on `reference.status == .ready`; the status is read
+      during `body`, which SwiftUI re-evaluates *before* the `.task` that reacts to it, so the
+      baseline was snapshotted one pass early and the sheet's own default asset read back as a
+      user edit — "Discard changes?" on an untouched form.
+- **Quick Add's pickers come from `ReferenceDataStore`, not from a fetch on open**
+  (`State/ReferenceDataStore.swift`, app-root environment, loaded by `MainTabView` on
+  `.task(id: activeHousehold?.id)` and re-loaded on `QuickAddStore.reloadToken`). The sheet used
+  to fetch accounts, categories, sub-portfolios, assets and counterparties when it was presented;
+  on a cold start those five requests queue behind the Dashboard's twelve, so on a real network
+  the account picker sat on a bare "Select" for ~6 seconds — indistinguishable from "this
+  household has no accounts", which is what sent people to the Accounts tab and back (#272).
+  Three rules the store encodes:
+    - **Accounts and categories are published before the portfolio sets are awaited**
+      (`.essentials` → `.ready`). An expense is the default mode and needs only those two;
+      making it wait on `/portfolio/assets` buys it nothing.
+    - **`hasEssentials` is a latch, not a reading of `status`.** A refresh that fails leaves the
+      previous accounts and categories in place and they are still the best answer available —
+      deriving the flag from the status made a failed refresh hide data the store was still
+      holding, reproducing the original symptom.
+    - **The sheet says which of three states it is in**: still loading (spinner), failed (the
+      message plus a Retry that force-reloads), or genuinely empty (no accounts yet). Leaving
+      every picker on "Select" for all three is the bug.
+
 - **API base URL** resolves in `APIClient.baseURL` via `AppConfig.defaultBaseURL`, which reads the `API_BASE_URL` Info.plist key (fed by the per-configuration `API_BASE_URL` build setting in `project.yml`, `$(API_BASE_URL)`; falls back to `http://localhost:8000`). **Debug builds only** additionally honour a runtime override (`UserDefaults` key `api_base_url`, editable in the More tab and on the login screen) for physical-device/LAN testing — the whole override (UI + read path) is wrapped in `#if DEBUG`, so it compiles out of Release/production builds. To ship against a real backend, set the Release `API_BASE_URL` build setting. ATS is opened for local networking only (`NSAllowsLocalNetworking`).
 - **View mode (Private/Household/Blended)** mirrors the web `ViewModeContext`. `ViewModeStore` (`State/ViewModeStore.swift`, app-root environment) holds the persisted mode + a `hasSecondPerson` flag; the `ViewModeSwitcher` toolbar control (`Views/Components/`) renders only once the active household has a second person (member beyond owner, or a pending invite — refreshed on household change in `MainTabView` and after invite changes via `setComposition`). `isVisible(ownerUserId:currentUserId:)` filters accounts/sub-portfolios (and their balances/holdings/transactions) on Dashboard, Accounts, Portfolio, and Transactions. Solo households always render `blended` (everything the user owns), so filtering is a no-op until a second person exists.
 - **Face ID vault lock** (`require_face_id_for_vault`, an existing backend field that neither the web nor mobile surfaced) is enforced only on iOS. `ViewModeStore` also owns the vault state: `configureVault(requireFaceId:)` (called from `MainTabView` on login / when the user record's flag changes) caches `BiometricAuth.isAvailable`; while `isVaultLocked` (setting on **and** device can authenticate **and** not yet unlocked), `isVisible` hides **all** private items regardless of view mode. Unlock is `LocalAuthentication` via `Support/BiometricAuth.swift` using `.deviceOwnerAuthentication` (Face ID / Touch ID with passcode fallback). **It fails open**: a device with no biometrics/passcode can't lock, so users are never shut out of their own data. `MainTabView` auto-prompts once on login/foreground and re-locks on `.background` (guarding against `.inactive`, since the biometric sheet itself makes the app inactive — locking there would loop). The `VaultLockButton` toolbar control shows a lock/unlock affordance when the feature is active. Note the backend **defaults this field to `false`** (flipped from `true` — a mandatory Face ID/passcode prompt before the first Dashboard load was pure friction for the common case of a solo household with no one to hide data from) — a user opts in from Privacy & Vault. The preview test user matches this default, so browser/simulator verification isn't blocked by the prompt unless it's turned on locally.
@@ -396,6 +424,10 @@ where tests pay off without a running backend:
   state, so unlike `cardCategoryId` (still hand-written for its own explicit-null requirement)
   there is no tri-state wrapper for this field.
 - `ViewModeStoreTests` — the Private/Household/Blended `isVisible` + `effectiveMode` rules.
+- `ReferenceDataStoreTests` — the non-fetching half of `State/ReferenceDataStore.swift`: that
+  no household is `.idle` rather than a failure, that `hasEssentials` survives a *failed
+  refresh* (the regression that reproduces #272's empty picker), and that a row created
+  inside Quick Add folds in without duplicating when the next refresh returns it.
 - `FormattersTests` — the backend-critical `Date.apiDateOnly` (exact); currency/percent
   helpers get locale-tolerant structural checks only (their output is Foundation's, not ours).
 - `DateParserTests` — the hand-rolled ISO-8601 scanner in `APIClient.swift`, asserted

--- a/ios/FinanceTracker/FinanceTrackerApp.swift
+++ b/ios/FinanceTracker/FinanceTrackerApp.swift
@@ -5,6 +5,7 @@ struct FinanceTrackerApp: App {
     @State private var session = SessionStore()
     @State private var quickAdd = QuickAddStore()
     @State private var viewMode = ViewModeStore()
+    @State private var reference = ReferenceDataStore()
 
     var body: some Scene {
         WindowGroup {
@@ -12,6 +13,7 @@ struct FinanceTrackerApp: App {
                 .environment(session)
                 .environment(quickAdd)
                 .environment(viewMode)
+                .environment(reference)
                 .task { await session.bootstrap() }
         }
     }

--- a/ios/FinanceTracker/State/ReferenceDataStore.swift
+++ b/ios/FinanceTracker/State/ReferenceDataStore.swift
@@ -1,0 +1,176 @@
+import Foundation
+import Observation
+
+/// The reference sets Quick Add fills its pickers from — accounts, categories,
+/// sub-portfolios, assets and counterparties — held at the app root and loaded once
+/// per household instead of once per sheet.
+///
+/// Quick Add used to fetch all five the moment it was presented. On a cold start those
+/// requests queue behind the Dashboard's batch, so on anything slower than localhost the
+/// sheet opened with an empty account picker for several seconds — indistinguishable from
+/// "this household has no accounts", which is what made people close it and go to the
+/// Accounts tab to wake the data up (#272). Fetching them when the household resolves
+/// means the sheet almost always opens with its pickers already filled, and the second
+/// open is free.
+///
+/// Accounts and categories are published **before** the portfolio sets are awaited: an
+/// expense — the default mode, and the overwhelmingly common one — needs only those two,
+/// and making it wait on `/portfolio/assets` buys it nothing.
+@MainActor
+@Observable
+final class ReferenceDataStore {
+    /// What the pickers can offer right now, and whether more is still coming.
+    enum Status: Equatable {
+        /// No household yet, so there is nothing to load.
+        case idle
+        /// In flight, and `accounts`/`categories` have not landed yet.
+        case loading
+        /// Accounts and categories are usable; the portfolio sets may still be in flight.
+        case essentials
+        case ready
+        case failed(String)
+    }
+
+    private(set) var accounts: [AccountResponse] = []
+    private(set) var categories: [CategoryResponse] = []
+    private(set) var subPortfolios: [SubPortfolioResponse] = []
+    private(set) var assets: [AssetResponse] = []
+    private(set) var counterparties: [Counterparty] = []
+    private(set) var status: Status = .idle
+
+    /// Accounts and categories have landed at least once for this household.
+    ///
+    /// Not derived from `status` alone: a *refresh* that fails (or is still in flight)
+    /// leaves the previous answer sitting in `accounts`/`categories`, and that answer is
+    /// still the best one available. Reading the status instead made a failed refresh
+    /// hide data the store was still holding, so Quick Add reopened with the pickers back
+    /// on "Select" — the very symptom this store exists to prevent.
+    private(set) var hasEssentials = false
+
+    /// The last load ended in an error (some sets may still be usable).
+    var isFailed: Bool {
+        if case .failed = status { return true }
+        return false
+    }
+
+    /// The message from the last failure, for the sheet's retry row.
+    var failureMessage: String? {
+        if case .failed(let message) = status { return message }
+        return nil
+    }
+
+    /// The household the data above describes. A load for a different one replaces
+    /// everything rather than merging — two households' accounts must never mix.
+    private var loadedHouseholdId: String?
+    private var inFlight: Task<Void, Never>?
+
+    /// Fetch the reference sets for `householdId`, unless they are already loaded (or
+    /// loading) for that same household. `force` re-fetches regardless — used after a
+    /// change is logged, and by the retry button.
+    func load(householdId: String?, force: Bool = false) async {
+        guard let householdId else {
+            inFlight?.cancel()
+            inFlight = nil
+            clear()
+            status = .idle
+            loadedHouseholdId = nil
+            return
+        }
+        // Already loaded, or already on its way — either way, don't start a second one.
+        // A previous failure is the exception: there is nothing to wait for there.
+        if !force, householdId == loadedHouseholdId, !isFailed {
+            await inFlight?.value
+            return
+        }
+        inFlight?.cancel()
+        if householdId != loadedHouseholdId { clear() }
+        loadedHouseholdId = householdId
+        status = .loading
+
+        let task = Task { [weak self] in
+            _ = await self?.fetch(householdId: householdId)
+        }
+        inFlight = task
+        await task.value
+    }
+
+    private func fetch(householdId: String) async {
+        do {
+            async let accountsReq: [AccountResponse] =
+                APIClient.shared.get("/accounts/household/\(householdId)")
+            async let categoriesReq: [CategoryResponse] =
+                APIClient.shared.get("/cashflow/categories/household/\(householdId)")
+            async let subsReq: [SubPortfolioResponse] =
+                APIClient.shared.get("/portfolio/subportfolios/household/\(householdId)")
+            async let assetsReq: [AssetResponse] = APIClient.shared.get("/portfolio/assets")
+            // Optional: nobody to split with is the ordinary case, and it must not stop
+            // Quick Add opening.
+            async let counterpartiesReq: [Counterparty]? = try? await APIClient.shared.get(
+                "/cashflow/counterparties/household/\(householdId)"
+            )
+
+            let (fetchedAccounts, fetchedCategories) = try await (accountsReq, categoriesReq)
+            guard !Task.isCancelled, loadedHouseholdId == householdId else { return }
+            // Published before the portfolio sets are awaited, so the account and
+            // category pickers fill as soon as their own requests land.
+            applyEssentials(accounts: fetchedAccounts, categories: fetchedCategories)
+
+            (subPortfolios, assets) = try await (subsReq, assetsReq)
+            counterparties = await counterpartiesReq ?? []
+            guard !Task.isCancelled, loadedHouseholdId == householdId else { return }
+            apply(status: .ready)
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled, loadedHouseholdId == householdId else { return }
+            // A failure part-way through leaves whatever did land usable rather than
+            // blanking the pickers; the status still says something went wrong.
+            apply(status: .failed(error.localizedDescription))
+        }
+    }
+
+    /// Publish the first stage. Kept as its own step rather than inlined so the
+    /// latch and the status can't drift apart, and so both are reachable from the tests
+    /// without a backend.
+    func applyEssentials(accounts: [AccountResponse], categories: [CategoryResponse]) {
+        self.accounts = accounts
+        self.categories = categories
+        hasEssentials = true
+        status = .essentials
+    }
+
+    /// Move the status without touching the data already published — which is the whole
+    /// point on a failed refresh.
+    func apply(status: Status) {
+        self.status = status
+    }
+
+    private func clear() {
+        hasEssentials = false
+        accounts = []
+        categories = []
+        subPortfolios = []
+        assets = []
+        counterparties = []
+    }
+
+    // MARK: - Local edits
+    //
+    // Quick Add can create a category, an asset or a counterparty from inside the sheet.
+    // Folding the new row in beats re-fetching: the sheet needs it selected immediately,
+    // and a round trip is the thing this store exists to avoid.
+
+    func add(category: CategoryResponse) {
+        guard !categories.contains(where: { $0.id == category.id }) else { return }
+        categories.append(category)
+    }
+
+    func add(asset: AssetResponse) {
+        guard !assets.contains(where: { $0.id == asset.id }) else { return }
+        assets.append(asset)
+    }
+
+    func setCounterparties(_ updated: [Counterparty]) {
+        counterparties = updated
+    }
+}

--- a/ios/FinanceTracker/Views/MainTabView.swift
+++ b/ios/FinanceTracker/Views/MainTabView.swift
@@ -9,6 +9,7 @@ struct MainTabView: View {
     @Environment(QuickAddStore.self) private var quickAdd
     @Environment(SessionStore.self) private var session
     @Environment(ViewModeStore.self) private var viewMode
+    @Environment(ReferenceDataStore.self) private var reference
     @Environment(\.scenePhase) private var scenePhase
     @State private var selection: AppTab = .dashboard
 
@@ -55,6 +56,18 @@ struct MainTabView: View {
         }
         .task(id: session.activeHousehold?.id) {
             await viewMode.refresh(householdId: session.activeHousehold?.id)
+        }
+        // Fill Quick Add's pickers as soon as there's a household to fill them from,
+        // rather than when the sheet opens — on a cold start those requests otherwise
+        // queue behind this screen's own batch and the sheet shows an empty account
+        // picker for seconds (#272).
+        .task(id: session.activeHousehold?.id) {
+            await reference.load(householdId: session.activeHousehold?.id)
+        }
+        // A logged change can create an account or move a balance, so the sheet's next
+        // open should not be working from the pre-change list.
+        .onChange(of: quickAdd.reloadToken) { _, _ in
+            Task { await reference.load(householdId: session.activeHousehold?.id, force: true) }
         }
         // Configure the private-vault lock from the user's setting when they log in / change,
         // then auto-prompt once so opening the app goes straight to the biometric unlock.

--- a/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
+++ b/ios/FinanceTracker/Views/QuickAdd/QuickAddView.swift
@@ -8,6 +8,7 @@ struct QuickAddView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(SessionStore.self) private var session
     @Environment(QuickAddStore.self) private var quickAdd
+    @Environment(ReferenceDataStore.self) private var reference
 
     enum Mode: String, CaseIterable, Identifiable {
         case expense, income, transfer, trade, dividend, balance
@@ -34,12 +35,12 @@ struct QuickAddView: View {
         }
     }
 
-    // Loaded data
-    @State private var accounts: [AccountResponse] = []
-    @State private var categories: [CategoryResponse] = []
-    @State private var subPortfolios: [SubPortfolioResponse] = []
-    @State private var assets: [AssetResponse] = []
-    @State private var loaded = false
+    // Reference data, loaded once per household at the app root rather than on every
+    // open — see `ReferenceDataStore` and #272.
+    private var accounts: [AccountResponse] { reference.accounts }
+    private var categories: [CategoryResponse] { reference.categories }
+    private var subPortfolios: [SubPortfolioResponse] { reference.subPortfolios }
+    private var assets: [AssetResponse] { reference.assets }
 
     // Shared fields
     @State private var mode: Mode = .expense
@@ -75,6 +76,8 @@ struct QuickAddView: View {
     @State private var settleFromCash = false
 
     @State private var isSaving = false
+    /// Defaults are picked once, when the reference data first arrives.
+    @State private var appliedDefaults = false
     @State private var showingNewCategory = false
     @State private var showingNewAsset = false
     @State private var errorMessage: String?
@@ -122,6 +125,8 @@ struct QuickAddView: View {
                         .listRowBackground(Color.clear)
                 }
 
+                referenceStatusSection
+
                 switch mode {
                 case .expense, .income: cashFlowFields
                 case .transfer: transferFields
@@ -152,10 +157,15 @@ struct QuickAddView: View {
                          fromAccountId, toAccountId, subPortfolioId, assetId,
                          tradeType, quantityText, priceText, settleFromCash],
                 // `applyDefaults()` picks the default account / category / sub-portfolio only
-                // once the fetch lands, so the baseline can't be taken before then.
-                settled: loaded
+                // once the reference data lands, so the baseline can't be taken before then.
+                settled: referenceSettled
             )
-            .task { await loadIfNeeded() }
+            // Normally a no-op: the app root loaded this when the household resolved. It
+            // still matters on the two paths that leave it unloaded — a household that
+            // changed while the sheet was closed, and a load that failed, which this
+            // retries on open.
+            .task { await reference.load(householdId: household?.id) }
+            .task(id: reference.status) { syncFromReference() }
             .onChange(of: mode) { resetForMode() }
             .onChange(of: accountId) { _, newValue in
                 // A pick from the old card is meaningless on a new one.
@@ -165,14 +175,14 @@ struct QuickAddView: View {
             .sheet(isPresented: $showingNewCategory) {
                 if let household {
                     CategoryEditView(category: nil, householdId: household.id, lockedType: mode == .income ? .income : .expense) { created in
-                        categories.append(created)
+                        reference.add(category: created)
                         categoryId = created.id
                     }
                 }
             }
             .sheet(isPresented: $showingNewAsset) {
                 AssetCreateView(defaultCurrency: selectedAsset?.currency ?? accounts.first?.currency ?? baseCurrency) { created in
-                    assets.append(created)
+                    reference.add(asset: created)
                     assetId = created.id
                 }
             }
@@ -406,24 +416,60 @@ struct QuickAddView: View {
         cardHeadroom = loaded.headroom
     }
 
-    private func loadIfNeeded() async {
-        guard !loaded, let household else { return }
-        do {
-            async let accountsReq: [AccountResponse] = APIClient.shared.get("/accounts/household/\(household.id)")
-            async let categoriesReq: [CategoryResponse] = APIClient.shared.get("/cashflow/categories/household/\(household.id)")
-            async let subsReq: [SubPortfolioResponse] = APIClient.shared.get("/portfolio/subportfolios/household/\(household.id)")
-            async let assetsReq: [AssetResponse] = APIClient.shared.get("/portfolio/assets")
-            // Optional: nobody to split with is the ordinary case, and it must
-            // not stop Quick Add opening.
-            async let counterpartiesReq: [Counterparty]? = try? await APIClient.shared.get(
-                "/cashflow/counterparties/household/\(household.id)"
-            )
-            (accounts, categories, subPortfolios, assets) = try await (accountsReq, categoriesReq, subsReq, assetsReq)
-            counterparties = await counterpartiesReq ?? []
-            loaded = true
-            applyDefaults()
-        } catch {
-            errorMessage = error.localizedDescription
+    /// True once the defaults below are final and the discard guard can snapshot its
+    /// baseline. It tracks `applyDefaults()` having run to completion, **not** the store
+    /// reaching `.ready`: the store's status is read during `body`, which SwiftUI
+    /// re-evaluates before the `.task` that reacts to it, so settling on the status alone
+    /// takes the baseline one pass too early and the sheet's own default asset reads back
+    /// as a user edit — "Discard changes?" on an untouched form.
+    private var referenceSettled: Bool { appliedDefaults || reference.isFailed }
+
+    /// Fold the store's latest into the sheet's own state. Called whenever the store's
+    /// status moves, so the pickers pick up the staged arrivals (accounts and categories
+    /// first, the portfolio sets a moment later).
+    private func syncFromReference() {
+        // The split section can create a counterparty inline, so the sheet owns a mutable
+        // copy. Merge rather than overwrite, or the second stage of the load would drop
+        // one the user had just added. (Dismissing the sheet bumps `reloadToken`, which
+        // re-fetches the store, so the addition isn't lost on the next open either.)
+        let known = Set(reference.counterparties.map(\.id))
+        counterparties = (reference.counterparties + counterparties.filter { !known.contains($0.id) })
+            .sorted { $0.name < $1.name }
+        guard reference.hasEssentials, !appliedDefaults else { return }
+        applyDefaults()
+        // Only once everything has landed are the sub-portfolio and asset defaults real,
+        // so the second stage gets its own pass before this is called done.
+        if reference.status == .ready { appliedDefaults = true }
+    }
+
+    /// Says which of the three states the pickers are in — still loading, failed, or
+    /// genuinely empty — instead of leaving every picker on a bare "Select", which reads
+    /// as "this household has no accounts" (#272).
+    @ViewBuilder
+    private var referenceStatusSection: some View {
+        if let message = reference.failureMessage {
+            Section {
+                Label(message, systemImage: "exclamationmark.triangle")
+                    .foregroundStyle(.red)
+                Button {
+                    Task { await reference.load(householdId: household?.id, force: true) }
+                } label: {
+                    Label("Retry", systemImage: "arrow.clockwise")
+                }
+            }
+        } else if !reference.hasEssentials {
+            Section {
+                HStack(spacing: 10) {
+                    ProgressView()
+                    Text("Loading your accounts…").foregroundStyle(.secondary)
+                }
+            }
+        } else if selectableAccounts(accounts).isEmpty {
+            Section {
+                Label("No accounts yet — add one from the Accounts tab first.",
+                      systemImage: "building.columns")
+                    .foregroundStyle(.secondary)
+            }
         }
     }
 

--- a/ios/FinanceTrackerTests/ReferenceDataStoreTests.swift
+++ b/ios/FinanceTrackerTests/ReferenceDataStoreTests.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Testing
+@testable import FinanceTracker
+
+/// `ReferenceDataStore` (`State/ReferenceDataStore.swift`) is what stops Quick Add opening
+/// with an empty account picker on a cold start (#272). Its fetching half needs a backend
+/// and isn't exercised here; what is exercised is the part that decides whether the
+/// pickers have something to show and how a locally-created row folds in — the two places
+/// the empty-picker bug can come back.
+@MainActor
+struct ReferenceDataStoreTests {
+
+    private func category(_ id: String, name: String = "Dining") -> CategoryResponse {
+        CategoryResponse(id: id, householdId: "hh", name: name, type: .expense, isSystem: false)
+    }
+
+    private func asset(_ id: String, ticker: String = "VOO") -> AssetResponse {
+        AssetResponse(id: id, ticker: ticker, name: ticker, type: "stock", currency: "USD", pricingMode: nil)
+    }
+
+    // MARK: hasEssentials
+
+    @Test func startsWithNothingToShow() {
+        let store = ReferenceDataStore()
+        #expect(store.status == .idle)
+        #expect(!store.hasEssentials)
+        #expect(!store.isFailed)
+        #expect(store.failureMessage == nil)
+    }
+
+    /// No household means nothing to load — and that is `.idle`, not a failure, so the
+    /// sheet shows neither a spinner nor an error.
+    @Test func noHouseholdClearsToIdle() async {
+        let store = ReferenceDataStore()
+        await store.load(householdId: nil)
+        #expect(store.status == .idle)
+        #expect(store.accounts.isEmpty)
+        #expect(!store.hasEssentials)
+    }
+
+    // MARK: failure reporting
+
+    @Test func failureExposesItsMessage() {
+        let store = ReferenceDataStore()
+        store.apply(status: .failed("Could not connect to the server."))
+        #expect(store.isFailed)
+        #expect(store.failureMessage == "Could not connect to the server.")
+    }
+
+    /// The regression this store was written to prevent, in miniature: a *refresh* that
+    /// fails must not take the previously-loaded pickers down with it. `hasEssentials`
+    /// therefore records that accounts and categories have arrived, rather than being read
+    /// back off the current status.
+    @Test func failedRefreshKeepsWhatAlreadyLanded() {
+        let store = ReferenceDataStore()
+        store.applyEssentials(accounts: [], categories: [category("c1")])
+        #expect(store.hasEssentials)
+        store.apply(status: .failed("offline"))
+        #expect(store.hasEssentials)
+        #expect(store.categories.count == 1)
+    }
+
+    // MARK: local edits
+
+    @Test func addsCategoryCreatedInTheSheet() {
+        let store = ReferenceDataStore()
+        store.add(category: category("c1"))
+        #expect(store.categories.map(\.id) == ["c1"])
+    }
+
+    /// Quick Add folds a newly-created row in *and* the next refresh returns it from the
+    /// server, so adding the same id twice must not double it up in the picker.
+    @Test func doesNotDuplicateAnExistingRow() {
+        let store = ReferenceDataStore()
+        store.add(category: category("c1"))
+        store.add(category: category("c1", name: "Dining (renamed)"))
+        #expect(store.categories.count == 1)
+
+        store.add(asset: asset("a1"))
+        store.add(asset: asset("a1"))
+        #expect(store.assets.count == 1)
+    }
+}


### PR DESCRIPTION
Fixes #272. Three commits — iOS, Android, web.

## What was happening

All three clients fetched Quick Add's reference data (accounts, categories, sub-portfolios, assets/recent) **the moment it was opened**, so it appeared with a bare "Select" / no accounts to parse against — with no spinner and no error, which reads as "this household has no accounts". That is why closing it, opening the Accounts tab and coming back looked like the fix.

Reproduced on each platform against a throttling reverse proxy simulating VPS latency.

| | mechanism | empty window |
|---|---|---|
| **iOS** | its 5 requests queue behind the Dashboard's 12 (URLSession caps connections per host) | ~6s |
| **Android** | no queueing (`Api` uses OkHttp `execute()` on `Dispatchers.IO`), but `MainScaffold` only composes the sheet while presented, so it refetched on **every** open | one round trip |
| **Web** | effect gated on `isOpen`; first ⌘K after a page load had no accounts to parse against | one round trip |

iOS log, the clearest case:

```
[87.16s -> 91.84s]  Dashboard batch (12 requests)
[91.74s -> 93.25s]  GET /accounts/household/...   <- Quick Add, ~6s after the tap
```

## The fix

One store per client, loaded when the household resolves and re-loaded after a change is logged — `ReferenceDataStore` (iOS), `ReferenceDataViewModel` (Android), `ReferenceDataContext` (web). Four rules, identical across all three:

- **Accounts and categories are published before the portfolio sets are awaited.** An expense is the default mode and needs only those two. On Android the defaults previously waited on all four, so the account stayed unselected until `/portfolio/assets` returned.
- **`hasEssentials` is a latch, not a reading of `status`** — a failed *refresh* keeps the previously loaded pickers usable rather than reproducing the original symptom.
- **The UI says which state it is in**: a spinner while loading, the error plus a **Retry** when the load failed, and "no accounts yet" only when that is genuinely true.
- **Requests are capped.** The web's recent-transaction call had no `?limit=`, so it pulled the household's entire history to display three rows.

Two platform-specific fixes found during verification:
- **iOS**: the discard guard settles on `appliedDefaults`, not the store's status. The status is read during `body`, which SwiftUI re-evaluates *before* the `.task` that reacts to it, so settling on it snapshotted the baseline one pass early and an untouched form asked "Discard changes?".
- **Web**: the loading banner is gated on `loading && !hasEssentials`, not `!hasEssentials` alone. The bar is mounted at the root, so it renders for a logged-out visitor and mid-onboarding, where `idle` would otherwise show a promise that never resolves.

## Verification

Every platform, same throttled cold start: the reference requests now go out in the first wave and land before the user gets there, and the picker shows **Test Checking / Dining** on open. Also verified on each: a failed refresh shows the error + Retry while keeping the pickers usable, Retry recovers, and logging an expense end to end still works. On web, after the initial page-load batch, toggling the bar three times issues **zero** further requests. On iOS, Cancel on an untouched form dismisses silently.

Tests: 295 iOS, 220 Android, 188 web — all passing, including new `ReferenceDataStoreTests` / `ReferenceDataViewModelTest` / `ReferenceDataContext.test.tsx` suites covering the no-household case, the failed-refresh latch, and de-duplication of a row created inline. The web typecheck baseline is unchanged (35 errors on `dev`; `frontend/AGENTS.md` said 38, now corrected).

## Out of scope, noted for later

- Every client still fetches `/accounts/household`, `/cashflow/categories`, `/portfolio/assets` and `/cards/household` from its screens separately from this store, so a cold start still issues each two or three times.
- Android's Quick Add has no split section and no merchant-code field (and so never fetched counterparties), unlike iOS. That parity gap predates this change.
- The web's command-bar search only ever searched the three most recent transactions; unchanged here, but it is odd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)